### PR TITLE
manifest: allow image interpolation

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use amber_compiler::{
-    CompileOptions, Compiler, ResolverRegistry,
+    CompileOptions, CompileOutput, Compiler, ResolverRegistry,
     bundle::{BundleBuilder, BundleLoader},
     reporter::{
         Reporter as _,
@@ -189,8 +189,7 @@ async fn compile(args: CompileArgs) -> Result<()> {
                 return Err(miette::Report::new(err));
             }
 
-            let scenario = output.scenario;
-            write_outputs(&outputs, &scenario, &args)?;
+            write_outputs(&outputs, &output.scenario, Some(&output), &args)?;
 
             if let Some(bundle_root) = resolve_bundle_root(&args)? {
                 let tree = bundle_tree.expect("bundle requested");
@@ -206,7 +205,7 @@ async fn compile(args: CompileArgs) -> Result<()> {
                 ));
             }
 
-            write_outputs(&outputs, &scenario, &args)?;
+            write_outputs(&outputs, &scenario, None, &args)?;
         }
     }
 
@@ -639,7 +638,12 @@ fn prepare_bundle_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn write_outputs(outputs: &OutputPaths, scenario: &Scenario, args: &CompileArgs) -> Result<()> {
+fn write_outputs(
+    outputs: &OutputPaths,
+    scenario: &Scenario,
+    output: Option<&CompileOutput>,
+    args: &CompileArgs,
+) -> Result<()> {
     if let Some(primary) = outputs.primary.as_ref() {
         write_primary_output(primary, scenario)?;
     }
@@ -663,12 +667,17 @@ fn write_outputs(outputs: &OutputPaths, scenario: &Scenario, args: &CompileArgs)
     }
 
     if let Some(kubernetes_dest) = outputs.kubernetes.as_ref() {
-        let reporter = KubernetesReporter {
-            config: KubernetesReporterConfig {
-                disable_networkpolicy_check: args.disable_networkpolicy_check,
-            },
+        let config = KubernetesReporterConfig {
+            disable_networkpolicy_check: args.disable_networkpolicy_check,
         };
-        let artifact = reporter.emit(scenario).map_err(miette::Report::new)?;
+        let artifact = if let Some(output) = output {
+            amber_compiler::reporter::kubernetes::render_kubernetes_with_output(output, &config)
+                .map_err(miette::Report::new)?
+        } else {
+            KubernetesReporter { config }
+                .emit(scenario)
+                .map_err(miette::Report::new)?
+        };
         write_kubernetes_output(kubernetes_dest, &artifact)?;
     }
 

--- a/cli/tests/ui/k8s_program_image_runtime_template_unsupported.args
+++ b/cli/tests/ui/k8s_program_image_runtime_template_unsupported.args
@@ -1,0 +1,2 @@
+--no-opt
+--kubernetes /tmp/amber-k8s-ui-output

--- a/cli/tests/ui/k8s_program_image_runtime_template_unsupported.cmd
+++ b/cli/tests/ui/k8s_program_image_runtime_template_unsupported.cmd
@@ -1,0 +1,1 @@
+compile

--- a/cli/tests/ui/k8s_program_image_runtime_template_unsupported.json5
+++ b/cli/tests/ui/k8s_program_image_runtime_template_unsupported.json5
@@ -1,0 +1,18 @@
+{
+  manifest_version: "0.1.0",
+  config_schema: {
+    type: "object",
+    properties: { tag: { type: "string" } },
+    required: ["tag"],
+    additionalProperties: false,
+  },
+  components: {
+    child: {
+      manifest: "./k8s_program_image_runtime_template_unsupported_child.json5",
+      config: { image: "busybox:${config.tag}" },
+    },
+  },
+  exports: {
+    child: "#child.child",
+  },
+}

--- a/cli/tests/ui/k8s_program_image_runtime_template_unsupported.stderr
+++ b/cli/tests/ui/k8s_program_image_runtime_template_unsupported.stderr
@@ -1,0 +1,10 @@
+Error:   × program.image in /child resolves to a mixed runtime image template, but
+  │ kubernetes output only supports runtime images that resolve to exactly one
+  │ concrete config value (for example `${config.image}`).
+    ╭─[<CARGO_MANIFEST_DIR>/tests/ui/k8s_program_image_runtime_template_unsupported.json5:12:24]
+ 11 │       manifest: "./k8s_program_image_runtime_template_unsupported_child.json5",
+ 12 │       config: { image: "busybox:${config.tag}" },
+    ·                        ───────────┬───────────
+    ·                                   ╰── component config image interpolation here
+ 13 │     },
+    ╰────

--- a/cli/tests/ui/k8s_program_image_runtime_template_unsupported_child.json5
+++ b/cli/tests/ui/k8s_program_image_runtime_template_unsupported_child.json5
@@ -1,0 +1,22 @@
+{
+  manifest_version: "0.1.0",
+  config_schema: {
+    type: "object",
+    properties: { image: { type: "string" } },
+    required: ["image"],
+    additionalProperties: false,
+  },
+  program: {
+    image: "${config.image}",
+    entrypoint: ["child"],
+    network: {
+      endpoints: [{ name: "http", port: 8080 }],
+    },
+  },
+  provides: {
+    child: { kind: "http", endpoint: "http" },
+  },
+  exports: {
+    child: "child",
+  },
+}

--- a/cli/tests/ui/k8s_program_image_runtime_template_unsupported_program_image.args
+++ b/cli/tests/ui/k8s_program_image_runtime_template_unsupported_program_image.args
@@ -1,0 +1,2 @@
+--no-opt
+--kubernetes /tmp/amber-k8s-ui-output

--- a/cli/tests/ui/k8s_program_image_runtime_template_unsupported_program_image.cmd
+++ b/cli/tests/ui/k8s_program_image_runtime_template_unsupported_program_image.cmd
@@ -1,0 +1,1 @@
+compile

--- a/cli/tests/ui/k8s_program_image_runtime_template_unsupported_program_image.json5
+++ b/cli/tests/ui/k8s_program_image_runtime_template_unsupported_program_image.json5
@@ -1,0 +1,18 @@
+{
+  manifest_version: "0.1.0",
+  config_schema: {
+    type: "object",
+    properties: { tag: { type: "string" } },
+    required: ["tag"],
+    additionalProperties: false,
+  },
+  components: {
+    child: {
+      manifest: "./k8s_program_image_runtime_template_unsupported_program_image_child.json5",
+      config: { tag: "${config.tag}" },
+    },
+  },
+  exports: {
+    child: "#child.child",
+  },
+}

--- a/cli/tests/ui/k8s_program_image_runtime_template_unsupported_program_image.stderr
+++ b/cli/tests/ui/k8s_program_image_runtime_template_unsupported_program_image.stderr
@@ -1,0 +1,10 @@
+Error:   × program.image in /child resolves to a mixed runtime image template, but
+  │ kubernetes output only supports runtime images that resolve to exactly one
+  │ concrete config value (for example `${config.image}`).
+    ╭─[<CARGO_MANIFEST_DIR>/tests/ui/k8s_program_image_runtime_template_unsupported_program_image_child.json5:10:12]
+  9 │   program: {
+ 10 │     image: "busybox:${config.tag}",
+    ·            ───────────┬───────────
+    ·                       ╰── program.image interpolation here
+ 11 │     entrypoint: ["child"],
+    ╰────

--- a/cli/tests/ui/k8s_program_image_runtime_template_unsupported_program_image_child.json5
+++ b/cli/tests/ui/k8s_program_image_runtime_template_unsupported_program_image_child.json5
@@ -1,0 +1,22 @@
+{
+  manifest_version: "0.1.0",
+  config_schema: {
+    type: "object",
+    properties: { tag: { type: "string" } },
+    required: ["tag"],
+    additionalProperties: false,
+  },
+  program: {
+    image: "busybox:${config.tag}",
+    entrypoint: ["child"],
+    network: {
+      endpoints: [{ name: "http", port: 8080 }],
+    },
+  },
+  provides: {
+    child: { kind: "http", endpoint: "http" },
+  },
+  exports: {
+    child: "child",
+  },
+}

--- a/compiler/src/binding_validation.rs
+++ b/compiler/src/binding_validation.rs
@@ -200,6 +200,12 @@ fn validate_manifest_binding_interpolations(
         src_name,
     };
 
+    if let Ok(image) = program.image.parse::<InterpolatedString>() {
+        let location = ProgramLocation::Image;
+        let span = location.span(source.as_ref(), spans);
+        validate_interpolated_string(&image, &ctx, location, span, &mut diagnostics);
+    }
+
     for (idx, arg) in program.args.0.iter().enumerate() {
         let location = ProgramLocation::Entrypoint(idx);
         let span = location.span(source.as_ref(), spans);
@@ -399,6 +405,7 @@ fn validate_interpolated_config_string(
 
 #[derive(Clone, Copy, Debug)]
 enum ProgramLocation<'a> {
+    Image,
     Entrypoint(usize),
     Env(&'a str),
 }
@@ -406,6 +413,7 @@ enum ProgramLocation<'a> {
 impl ProgramLocation<'_> {
     fn label(self) -> String {
         match self {
+            ProgramLocation::Image => "program.image".to_string(),
             ProgramLocation::Entrypoint(idx) => format!("program.entrypoint[{idx}]"),
             ProgramLocation::Env(key) => format!("program.env.{key}"),
         }
@@ -414,6 +422,9 @@ impl ProgramLocation<'_> {
     fn span(self, source: &str, spans: &ManifestSpans) -> SourceSpan {
         let root = (0usize, source.len()).into();
         match self {
+            ProgramLocation::Image => span_for_json_pointer(source, root, "/program/image")
+                .or_else(|| spans.program.as_ref().map(|p| p.whole))
+                .unwrap_or_else(|| (0usize, 0usize).into()),
             ProgramLocation::Entrypoint(idx) => {
                 for key in ["args", "entrypoint"] {
                     let pointer = format!("/program/{key}/{idx}");

--- a/compiler/src/linker.rs
+++ b/compiler/src/linker.rs
@@ -951,54 +951,62 @@ fn validate_config_tree(
         let component_path = component_path_for(components, id);
         let site = ConfigErrorSite::new(components, provenance, store, id).config_site();
 
+        let mut validate_config_ref = |location: String, query: &str| {
+            let interp_suffix = if query.is_empty() {
+                "".to_string()
+            } else {
+                format!(".{query}")
+            };
+            let Some(schema) = schema else {
+                errors.push(Error::InvalidConfig {
+                    component_path: component_path.clone(),
+                    message: format!(
+                        "{location} references ${{config{interp_suffix}}}, but this component \
+                         does not declare `config_schema`"
+                    ),
+                    src: site.src.clone(),
+                    span: site.span,
+                    label: "config definition required".to_string(),
+                    related: Vec::new(),
+                });
+                return;
+            };
+            match rc::schema_lookup(schema, query) {
+                Ok(rc::SchemaLookup::Found) | Ok(rc::SchemaLookup::Unknown) => {}
+                Err(e) => {
+                    errors.push(Error::InvalidConfig {
+                        component_path: component_path.clone(),
+                        message: format!(
+                            "invalid ${{config{interp_suffix}}} reference in {location}: {e}"
+                        ),
+                        src: site.src.clone(),
+                        span: site.span,
+                        label: "invalid config reference".to_string(),
+                        related: Vec::new(),
+                    });
+                }
+            }
+        };
+
+        if let Ok(image) = program.image.parse::<InterpolatedString>() {
+            for part in &image.parts {
+                let InterpolatedPart::Interpolation { source, query } = part else {
+                    continue;
+                };
+                if *source == InterpolationSource::Config {
+                    validate_config_ref("program.image".to_string(), query);
+                }
+            }
+        }
+
         // entrypoint / env are structured (InterpolatedString), so we never need to re-parse `${...}`.
         for (arg_idx, arg) in program.args.0.iter().enumerate() {
             for part in &arg.parts {
                 let InterpolatedPart::Interpolation { source, query } = part else {
                     continue;
                 };
-                if *source != InterpolationSource::Config {
-                    continue;
-                }
-                let Some(schema) = schema else {
-                    errors.push(Error::InvalidConfig {
-                        component_path: component_path.clone(),
-                        message: format!(
-                            "program.entrypoint[{arg_idx}] references ${{config{}}}, but this \
-                             component does not declare `config_schema`",
-                            if query.is_empty() {
-                                "".to_string()
-                            } else {
-                                format!(".{query}")
-                            }
-                        ),
-                        src: site.src.clone(),
-                        span: site.span,
-                        label: "config definition required".to_string(),
-                        related: Vec::new(),
-                    });
-                    continue;
-                };
-                match rc::schema_lookup(schema, query.as_str()) {
-                    Ok(rc::SchemaLookup::Found) | Ok(rc::SchemaLookup::Unknown) => {}
-                    Err(e) => {
-                        errors.push(Error::InvalidConfig {
-                            component_path: component_path.clone(),
-                            message: format!(
-                                "invalid ${{config{}}} reference in \
-                                 program.entrypoint[{arg_idx}]: {e}",
-                                if query.is_empty() {
-                                    "".to_string()
-                                } else {
-                                    format!(".{query}")
-                                }
-                            ),
-                            src: site.src.clone(),
-                            span: site.span,
-                            label: "invalid config reference".to_string(),
-                            related: Vec::new(),
-                        });
-                    }
+                if *source == InterpolationSource::Config {
+                    validate_config_ref(format!("program.entrypoint[{arg_idx}]"), query);
                 }
             }
         }
@@ -1008,47 +1016,8 @@ fn validate_config_tree(
                 let InterpolatedPart::Interpolation { source, query } = part else {
                     continue;
                 };
-                if *source != InterpolationSource::Config {
-                    continue;
-                }
-                let Some(schema) = schema else {
-                    errors.push(Error::InvalidConfig {
-                        component_path: component_path.clone(),
-                        message: format!(
-                            "program.env.{k} references ${{config{}}}, but this component does \
-                             not declare `config_schema`",
-                            if query.is_empty() {
-                                "".to_string()
-                            } else {
-                                format!(".{query}")
-                            }
-                        ),
-                        src: site.src.clone(),
-                        span: site.span,
-                        label: "config definition required".to_string(),
-                        related: Vec::new(),
-                    });
-                    continue;
-                };
-                match rc::schema_lookup(schema, query.as_str()) {
-                    Ok(rc::SchemaLookup::Found) | Ok(rc::SchemaLookup::Unknown) => {}
-                    Err(e) => {
-                        errors.push(Error::InvalidConfig {
-                            component_path: component_path.clone(),
-                            message: format!(
-                                "invalid ${{config{}}} reference in program.env.{k}: {e}",
-                                if query.is_empty() {
-                                    "".to_string()
-                                } else {
-                                    format!(".{query}")
-                                }
-                            ),
-                            src: site.src.clone(),
-                            span: site.span,
-                            label: "invalid config reference".to_string(),
-                            related: Vec::new(),
-                        });
-                    }
+                if *source == InterpolationSource::Config {
+                    validate_config_ref(format!("program.env.{k}"), query);
                 }
             }
         }
@@ -2060,6 +2029,13 @@ fn collect_program_slot_uses(manifest: &Manifest) -> HashSet<String> {
     };
 
     let mut used_all = false;
+    if let Ok(image) = program.image.parse::<InterpolatedString>() {
+        used_all = add_program_slot_uses(manifest, &mut uses, &image);
+        if used_all {
+            return uses;
+        }
+    }
+
     for arg in &program.args.0 {
         used_all = add_program_slot_uses(manifest, &mut uses, arg);
         if used_all {

--- a/compiler/src/passes/dce/mod.rs
+++ b/compiler/src/passes/dce/mod.rs
@@ -136,6 +136,13 @@ fn mark_used_slots(
         }
     };
 
+    if let Ok(image) = program.image.parse::<amber_manifest::InterpolatedString>()
+        && image.visit_slot_uses(|slot| mark_slot(component.id.0, slot, live_slots, work))
+    {
+        mark_all(live_slots, work);
+        return;
+    }
+
     for arg in &program.args.0 {
         if arg.visit_slot_uses(|slot| mark_slot(component.id.0, slot, live_slots, work)) {
             mark_all(live_slots, work);

--- a/compiler/src/slot_validation.rs
+++ b/compiler/src/slot_validation.rs
@@ -94,6 +94,12 @@ fn validate_manifest_slot_interpolations(
         src_name,
     };
 
+    if let Ok(image) = program.image.parse::<InterpolatedString>() {
+        let location = SlotLocation::Image;
+        let span = location.span(source.as_ref(), spans);
+        validate_interpolated_string(&image, &ctx, location, span, &mut diagnostics);
+    }
+
     for (idx, arg) in program.args.0.iter().enumerate() {
         let location = SlotLocation::Entrypoint(idx);
         let span = location.span(source.as_ref(), spans);
@@ -111,6 +117,7 @@ fn validate_manifest_slot_interpolations(
 
 #[derive(Clone, Copy, Debug)]
 enum SlotLocation<'a> {
+    Image,
     Entrypoint(usize),
     Env(&'a str),
 }
@@ -118,6 +125,7 @@ enum SlotLocation<'a> {
 impl SlotLocation<'_> {
     fn label(self) -> String {
         match self {
+            SlotLocation::Image => "program.image".to_string(),
             SlotLocation::Entrypoint(idx) => format!("program.entrypoint[{idx}]"),
             SlotLocation::Env(key) => format!("program.env.{key}"),
         }
@@ -126,6 +134,9 @@ impl SlotLocation<'_> {
     fn span(self, source: &str, spans: &ManifestSpans) -> SourceSpan {
         let root = (0usize, source.len()).into();
         match self {
+            SlotLocation::Image => span_for_json_pointer(source, root, "/program/image")
+                .or_else(|| spans.program.as_ref().map(|p| p.whole))
+                .unwrap_or_else(|| (0usize, 0usize).into()),
             SlotLocation::Entrypoint(idx) => {
                 for key in ["args", "entrypoint"] {
                     let pointer = format!("/program/{key}/{idx}");

--- a/compiler/src/targets/mesh/config.rs
+++ b/compiler/src/targets/mesh/config.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use amber_config as rc;
 use amber_manifest::{InterpolatedPart, InterpolationSource};
@@ -20,19 +20,71 @@ pub(crate) struct ConfigPlan {
     pub(crate) root_leaves: Vec<rc::SchemaLeaf>,
     pub(crate) program_plans: HashMap<ComponentId, ProgramPlan>,
     pub(crate) uses_helper: bool,
+    pub(crate) uses_runtime_image: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ProgramImagePart {
+    Literal(String),
+    RootConfigPath(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ProgramImagePlan {
+    Static(String),
+    RuntimeTemplate(Vec<ProgramImagePart>),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ProgramImageOrigin {
+    ProgramImage,
+    ComponentConfigPath(String),
+}
+
+impl ProgramImagePlan {
+    pub(crate) fn collect_runtime_root_paths(&self, out: &mut BTreeSet<String>) {
+        let Self::RuntimeTemplate(parts) = self else {
+            return;
+        };
+        for part in parts {
+            if let ProgramImagePart::RootConfigPath(path) = part {
+                out.insert(path.clone());
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
 pub(crate) enum ProgramPlan {
     Direct {
+        image: ProgramImagePlan,
+        image_origin: ProgramImageOrigin,
         entrypoint: Vec<String>,
         env: BTreeMap<String, String>,
     },
     Helper {
+        image: ProgramImagePlan,
+        image_origin: ProgramImageOrigin,
         template_spec: TemplateSpec,
         component_template: rc::RootConfigTemplate,
         component_schema: Value,
     },
+}
+
+impl ProgramPlan {
+    pub(crate) fn image(&self) -> &ProgramImagePlan {
+        match self {
+            Self::Direct { image, .. } => image,
+            Self::Helper { image, .. } => image,
+        }
+    }
+
+    pub(crate) fn image_origin(&self) -> &ProgramImageOrigin {
+        match self {
+            Self::Direct { image_origin, .. } => image_origin,
+            Self::Helper { image_origin, .. } => image_origin,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -76,9 +128,16 @@ pub(crate) fn build_config_plan(
     } else {
         Vec::new()
     };
+    let root_leaf_paths: BTreeSet<&str> =
+        root_leaves.iter().map(|leaf| leaf.path.as_str()).collect();
 
     let mut program_plans = HashMap::new();
+    // `uses_helper` means at least one component needs helper-backed runtime
+    // interpolation in program.entrypoint/program.env.
     let mut uses_helper = false;
+    // `uses_runtime_image` means at least one component has runtime-derived
+    // program.image interpolation. This is tracked separately from helper mode.
+    let mut uses_runtime_image = false;
 
     for id in program_components {
         let c = scenario.component(*id);
@@ -120,10 +179,25 @@ pub(crate) fn build_config_plan(
         if matches!(plan, ProgramPlan::Helper { .. }) {
             uses_helper = true;
         }
+        let mut runtime_paths = BTreeSet::new();
+        plan.image().collect_runtime_root_paths(&mut runtime_paths);
+        if !runtime_paths.is_empty() {
+            uses_runtime_image = true;
+        }
+        for path in runtime_paths {
+            if !root_leaf_paths.contains(path.as_str()) {
+                return Err(MeshError::new(format!(
+                    "program.image in {} requires runtime config path config.{path}, but runtime \
+                     image interpolation only supports paths that resolve to one concrete root \
+                     config value",
+                    component_label(scenario, *id)
+                )));
+            }
+        }
         program_plans.insert(*id, plan);
     }
 
-    if uses_helper && root_schema.is_none() {
+    if (uses_helper || uses_runtime_image) && root_schema.is_none() {
         return Err(MeshError::new(
             "root component must declare `config_schema` when runtime config interpolation is \
              required",
@@ -135,6 +209,7 @@ pub(crate) fn build_config_plan(
         root_leaves,
         program_plans,
         uses_helper,
+        uses_runtime_image,
     })
 }
 
@@ -299,6 +374,12 @@ enum ConfigResolution {
     Runtime,
 }
 
+#[derive(Debug)]
+enum ImageConfigResolution {
+    Static(String),
+    RuntimeTemplate(Vec<ProgramImagePart>),
+}
+
 fn resolve_config_query_for_program(
     template: Option<&rc::ConfigNode>,
     query: &str,
@@ -307,36 +388,170 @@ fn resolve_config_query_for_program(
         return Ok(ConfigResolution::Runtime);
     };
 
+    let cur = if query.is_empty() {
+        template
+    } else {
+        let mut current = template;
+        for seg in query.split('.') {
+            if seg.is_empty() {
+                return Err(MeshError::new(format!(
+                    "invalid config path {query:?}: empty segment"
+                )));
+            }
+            match current {
+                rc::ConfigNode::Object(map) => {
+                    let Some(next) = map.get(seg) else {
+                        return Err(MeshError::new(format!(
+                            "config.{query} not found (missing key {seg:?})"
+                        )));
+                    };
+                    current = next;
+                }
+                rc::ConfigNode::ConfigRef(_) => return Ok(ConfigResolution::Runtime),
+                _ => {
+                    return Err(MeshError::new(format!(
+                        "config.{query} not found (encountered non-object before segment {seg:?})"
+                    )));
+                }
+            }
+        }
+        current
+    };
+
+    if !cur.contains_runtime() {
+        let v = cur
+            .evaluate_static()
+            .map_err(|e| MeshError::new(e.to_string()))?;
+        Ok(ConfigResolution::Static(
+            rc::stringify_for_interpolation(&v).map_err(|e| MeshError::new(e.to_string()))?,
+        ))
+    } else {
+        Ok(ConfigResolution::Runtime)
+    }
+}
+
+fn resolve_program_image_runtime_node(
+    node: &rc::ConfigNode,
+) -> Result<ImageConfigResolution, MeshError> {
+    match node {
+        rc::ConfigNode::ConfigRef(path) => {
+            if path.is_empty() {
+                return Err(MeshError::new(
+                    "program.image cannot reference the entire runtime config object; reference a \
+                     string leaf like ${config.image}",
+                ));
+            }
+            Ok(ImageConfigResolution::RuntimeTemplate(vec![
+                ProgramImagePart::RootConfigPath(path.clone()),
+            ]))
+        }
+        rc::ConfigNode::StringTemplate(parts) => {
+            let mut out: Vec<ProgramImagePart> = Vec::with_capacity(parts.len());
+            for part in parts {
+                match part {
+                    TemplatePart::Lit { lit } => {
+                        if !lit.is_empty() {
+                            out.push(ProgramImagePart::Literal(lit.clone()));
+                        }
+                    }
+                    TemplatePart::Config { config } => {
+                        if config.is_empty() {
+                            return Err(MeshError::new(
+                                "program.image cannot reference the entire runtime config object; \
+                                 reference a string leaf like ${config.image}",
+                            ));
+                        }
+                        out.push(ProgramImagePart::RootConfigPath(config.clone()));
+                    }
+                    TemplatePart::Binding { binding, .. } => {
+                        return Err(MeshError::new(format!(
+                            "failed to resolve runtime image template: unresolved \
+                             bindings.{binding} interpolation"
+                        )));
+                    }
+                }
+            }
+            if out.is_empty() {
+                return Err(MeshError::new(
+                    "internal error: produced empty runtime template for program.image",
+                ));
+            }
+            Ok(ImageConfigResolution::RuntimeTemplate(out))
+        }
+        _ => Err(MeshError::new(
+            "program.image cannot interpolate a runtime-derived non-string config value; use a \
+             string config leaf containing the full image reference",
+        )),
+    }
+}
+
+fn resolve_config_query_for_program_image(
+    template: Option<&rc::ConfigNode>,
+    query: &str,
+) -> Result<ImageConfigResolution, MeshError> {
+    let Some(template) = template else {
+        if query.is_empty() {
+            return Err(MeshError::new(
+                "program.image cannot reference the entire runtime config object; reference a \
+                 string leaf like ${config.image}",
+            ));
+        }
+        for seg in query.split('.') {
+            if seg.is_empty() {
+                return Err(MeshError::new(format!(
+                    "invalid config path {query:?}: empty segment"
+                )));
+            }
+        }
+        return Ok(ImageConfigResolution::RuntimeTemplate(vec![
+            ProgramImagePart::RootConfigPath(query.to_string()),
+        ]));
+    };
+
     if query.is_empty() {
         return if !template.contains_runtime() {
             let v = template
                 .evaluate_static()
                 .map_err(|e| MeshError::new(e.to_string()))?;
-            Ok(ConfigResolution::Static(
+            Ok(ImageConfigResolution::Static(
                 rc::stringify_for_interpolation(&v).map_err(|e| MeshError::new(e.to_string()))?,
             ))
         } else {
-            Ok(ConfigResolution::Runtime)
+            resolve_program_image_runtime_node(template)
         };
     }
 
-    let mut cur = template;
-    for seg in query.split('.') {
+    let segments = query.split('.').collect::<Vec<_>>();
+    for seg in &segments {
         if seg.is_empty() {
             return Err(MeshError::new(format!(
                 "invalid config path {query:?}: empty segment"
             )));
         }
+    }
+
+    let mut cur = template;
+    for (idx, seg) in segments.iter().enumerate() {
         match cur {
             rc::ConfigNode::Object(map) => {
-                let Some(next) = map.get(seg) else {
+                let Some(next) = map.get(*seg) else {
                     return Err(MeshError::new(format!(
                         "config.{query} not found (missing key {seg:?})"
                     )));
                 };
                 cur = next;
             }
-            rc::ConfigNode::ConfigRef(_) => return Ok(ConfigResolution::Runtime),
+            rc::ConfigNode::ConfigRef(path) => {
+                let suffix = segments[idx..].join(".");
+                let full = if path.is_empty() {
+                    suffix
+                } else {
+                    format!("{path}.{suffix}")
+                };
+                return Ok(ImageConfigResolution::RuntimeTemplate(vec![
+                    ProgramImagePart::RootConfigPath(full),
+                ]));
+            }
             _ => {
                 return Err(MeshError::new(format!(
                     "config.{query} not found (encountered non-object before segment {seg:?})"
@@ -349,11 +564,11 @@ fn resolve_config_query_for_program(
         let v = cur
             .evaluate_static()
             .map_err(|e| MeshError::new(e.to_string()))?;
-        Ok(ConfigResolution::Static(
+        Ok(ImageConfigResolution::Static(
             rc::stringify_for_interpolation(&v).map_err(|e| MeshError::new(e.to_string()))?,
         ))
     } else {
-        Ok(ConfigResolution::Runtime)
+        resolve_program_image_runtime_node(cur)
     }
 }
 
@@ -374,6 +589,28 @@ fn render_template_string_static(ts: &TemplateString) -> Result<String, MeshErro
     Ok(out)
 }
 
+fn push_image_literal(parts: &mut Vec<ProgramImagePart>, lit: impl Into<String>) {
+    let lit = lit.into();
+    if lit.is_empty() {
+        return;
+    }
+    match parts.last_mut() {
+        Some(ProgramImagePart::Literal(existing)) => existing.push_str(&lit),
+        _ => parts.push(ProgramImagePart::Literal(lit)),
+    }
+}
+
+fn extend_image_parts(parts: &mut Vec<ProgramImagePart>, extra: Vec<ProgramImagePart>) {
+    for part in extra {
+        match part {
+            ProgramImagePart::Literal(lit) => push_image_literal(parts, lit),
+            ProgramImagePart::RootConfigPath(path) => {
+                parts.push(ProgramImagePart::RootConfigPath(path))
+            }
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_program_plan(
     scenario: &Scenario,
@@ -386,7 +623,100 @@ fn build_program_plan(
     component_template: &rc::RootConfigTemplate,
 ) -> Result<ProgramPlan, MeshError> {
     let mut entrypoint_ts: Vec<TemplateString> = Vec::new();
-    let mut needs_helper = false;
+    // Helper mode is required only for runtime config interpolation in
+    // program.entrypoint/program.env (not for program.image runtime interpolation).
+    let mut needs_helper_for_program_templates = false;
+    let mut image_parts: Vec<ProgramImagePart> = Vec::new();
+    let image = program
+        .image
+        .parse::<amber_manifest::InterpolatedString>()
+        .map_err(|err| {
+            MeshError::new(format!(
+                "failed to parse program.image interpolation in {}: {err}",
+                component_label(scenario, id)
+            ))
+        })?;
+    // If program.image is exactly one `${config...}` interpolation, image diagnostics should
+    // point at the corresponding component config path; otherwise they should point at
+    // program.image itself.
+    let image_origin = match image.parts.as_slice() {
+        [
+            InterpolatedPart::Interpolation {
+                source: InterpolationSource::Config,
+                query,
+            },
+        ] => ProgramImageOrigin::ComponentConfigPath(query.clone()),
+        _ => ProgramImageOrigin::ProgramImage,
+    };
+
+    for part in &image.parts {
+        match part {
+            InterpolatedPart::Literal(lit) => push_image_literal(&mut image_parts, lit.clone()),
+            InterpolatedPart::Interpolation { source, query } => match source {
+                InterpolationSource::Slots => {
+                    let value = resolve_slot_query(slots, query).map_err(|e| {
+                        MeshError::new(format!(
+                            "failed to resolve slot query in {}: {e}",
+                            component_label(scenario, id)
+                        ))
+                    })?;
+                    push_image_literal(&mut image_parts, value);
+                }
+                InterpolationSource::Bindings => {
+                    let value = resolve_binding_query(bindings, query).map_err(|e| {
+                        MeshError::new(format!(
+                            "failed to resolve binding query in {}: {e}",
+                            component_label(scenario, id)
+                        ))
+                    })?;
+                    push_image_literal(&mut image_parts, value);
+                }
+                InterpolationSource::Config => {
+                    match resolve_config_query_for_program_image(template_opt, query)? {
+                        ImageConfigResolution::Static(value) => {
+                            push_image_literal(&mut image_parts, value);
+                        }
+                        ImageConfigResolution::RuntimeTemplate(parts) => {
+                            extend_image_parts(&mut image_parts, parts);
+                        }
+                    }
+                }
+                other => {
+                    return Err(MeshError::new(format!(
+                        "unsupported interpolation source {other} in {} program.image",
+                        component_label(scenario, id)
+                    )));
+                }
+            },
+            _ => {
+                return Err(MeshError::new(format!(
+                    "unsupported interpolation part in {} program.image",
+                    component_label(scenario, id)
+                )));
+            }
+        }
+    }
+    if image_parts.is_empty() {
+        return Err(MeshError::new(format!(
+            "internal error: produced empty image template for {} program.image",
+            component_label(scenario, id)
+        )));
+    }
+    let image = if image_parts
+        .iter()
+        .any(|part| matches!(part, ProgramImagePart::RootConfigPath(_)))
+    {
+        ProgramImagePlan::RuntimeTemplate(image_parts)
+    } else {
+        let mut rendered = String::new();
+        for part in image_parts {
+            let ProgramImagePart::Literal(lit) = part else {
+                unreachable!("runtime root config path was handled above");
+            };
+            rendered.push_str(&lit);
+        }
+        ProgramImagePlan::Static(rendered)
+    };
 
     for (idx, arg) in program.args.0.iter().enumerate() {
         let mut ts: TemplateString = Vec::new();
@@ -417,7 +747,7 @@ fn build_program_plan(
                             ConfigResolution::Static(v) => ts.push(TemplatePart::lit(v)),
                             ConfigResolution::Runtime => {
                                 ts.push(TemplatePart::config(query.clone()));
-                                needs_helper = true;
+                                needs_helper_for_program_templates = true;
                             }
                         }
                     }
@@ -476,7 +806,7 @@ fn build_program_plan(
                             ConfigResolution::Static(vv) => ts.push(TemplatePart::lit(vv)),
                             ConfigResolution::Runtime => {
                                 ts.push(TemplatePart::config(query.clone()));
-                                needs_helper = true;
+                                needs_helper_for_program_templates = true;
                             }
                         }
                     }
@@ -498,7 +828,7 @@ fn build_program_plan(
         env_ts.insert(k.clone(), ts);
     }
 
-    if needs_helper {
+    if needs_helper_for_program_templates {
         let schema = component_schema.ok_or_else(|| {
             MeshError::new(format!(
                 "component {} requires config_schema when using runtime config interpolation",
@@ -514,6 +844,8 @@ fn build_program_plan(
         };
 
         Ok(ProgramPlan::Helper {
+            image,
+            image_origin,
             template_spec: spec,
             component_template: component_template.clone(),
             component_schema: schema.clone(),
@@ -530,6 +862,8 @@ fn build_program_plan(
         }
 
         Ok(ProgramPlan::Direct {
+            image,
+            image_origin,
             entrypoint: rendered_entrypoint,
             env: rendered_env,
         })

--- a/compiler/src/targets/mesh/docker_compose/mod.rs
+++ b/compiler/src/targets/mesh/docker_compose/mod.rs
@@ -15,7 +15,10 @@ use crate::{
     targets::mesh::{
         LOCAL_NETWORK_CIDRS,
         addressing::{Addressing, RouterPortBases, WorkloadId, build_address_plan},
-        config::{ProgramPlan, encode_helper_payload, encode_schema_b64},
+        config::{
+            ProgramImagePart, ProgramImagePlan, ProgramPlan, encode_helper_payload,
+            encode_schema_b64,
+        },
         internal_images::resolve_internal_images,
         plan::{
             MeshOptions, ResolvedBinding, ResolvedExport, ResolvedExternalBinding, component_label,
@@ -630,9 +633,11 @@ fn render_docker_compose_inner(s: &Scenario) -> DcResult<String> {
     )
     .map_err(|e| DockerComposeError::Other(e.to_string()))?;
 
-    // Root schema payloads + AMBER_CONFIG_* env list are only needed if at least one service uses the helper.
+    // Root schema payload + AMBER_CONFIG_* service env forwarding are helper-only.
+    // Runtime program.image interpolation is rendered directly in `image:` and
+    // resolved by Docker Compose variable substitution.
     let mut root_schema_b64: Option<String> = None;
-    let mut root_env_entries: Vec<String> = Vec::new();
+    let mut helper_root_env_entries: Vec<String> = Vec::new();
 
     if config_plan.uses_helper {
         let root_schema = config_plan
@@ -648,15 +653,21 @@ fn render_docker_compose_inner(s: &Scenario) -> DcResult<String> {
             let var = rc::env_var_for_path(&leaf.path)
                 .map_err(|e| format!("failed to map config path {} to env var: {e}", leaf.path))?;
             if leaf.required {
-                root_env_entries.push(format!("{var}=${{{var}?missing config.{}}}", leaf.path));
+                helper_root_env_entries
+                    .push(format!("{var}=${{{var}?missing config.{}}}", leaf.path));
             } else {
-                root_env_entries.push(var);
+                helper_root_env_entries.push(var);
             }
         }
     }
 
     let program_plans = &config_plan.program_plans;
     let any_helper = config_plan.uses_helper;
+    let root_leaf_by_path: BTreeMap<&str, &rc::SchemaLeaf> = config_plan
+        .root_leaves
+        .iter()
+        .map(|leaf| (leaf.path.as_str(), leaf))
+        .collect();
 
     let mut compose = DockerComposeFile::default();
 
@@ -754,7 +765,6 @@ fn render_docker_compose_inner(s: &Scenario) -> DcResult<String> {
 
     // Emit services in stable (component id) order, sidecar then program.
     for id in program_components {
-        let c = s.component(*id);
         let svc = names.get(id).unwrap();
 
         let inbound_allow = map_allowed_hosts(address_plan.allow.for_component(*id))?;
@@ -774,12 +784,12 @@ fn render_docker_compose_inner(s: &Scenario) -> DcResult<String> {
             sidecar_service(&svc.sidecar, &images.sidecar, script),
         );
 
-        let program = c.program.as_ref().unwrap();
-        let mut program_service = Service::new(program.image.as_str());
-        program_service.network_mode = Some(format!("service:{}", svc.sidecar));
-
         // depends_on: own sidecar + strong deps provider programs (+ amber-init for helper-backed services)
         let program_plan = program_plans.get(id).expect("program plan computed");
+        let image = render_compose_image(program_plan.image(), &root_leaf_by_path)
+            .map_err(DockerComposeError::Other)?;
+        let mut program_service = Service::new(image);
+        program_service.network_mode = Some(format!("service:{}", svc.sidecar));
         let mut deps: Vec<(String, &'static str)> = Vec::new();
         if any_helper && matches!(program_plan, ProgramPlan::Helper { .. }) {
             deps.push((
@@ -804,7 +814,9 @@ fn render_docker_compose_inner(s: &Scenario) -> DcResult<String> {
         program_service.depends_on = build_depends_on(any_helper, deps);
 
         match program_plan {
-            ProgramPlan::Direct { entrypoint, env } => {
+            ProgramPlan::Direct {
+                entrypoint, env, ..
+            } => {
                 // Use entrypoint so image entrypoints are ignored.
                 let entrypoint = entrypoint
                     .iter()
@@ -824,6 +836,7 @@ fn render_docker_compose_inner(s: &Scenario) -> DcResult<String> {
                 template_spec,
                 component_template,
                 component_schema,
+                ..
             } => {
                 let label = component_label(s, *id);
                 let payload = encode_helper_payload(
@@ -841,7 +854,7 @@ fn render_docker_compose_inner(s: &Scenario) -> DcResult<String> {
                 program_service.entrypoint =
                     Some(vec![HELPER_BIN_PATH.to_string(), "run".to_string()]);
 
-                let mut env_entries = root_env_entries.clone();
+                let mut env_entries = helper_root_env_entries.clone();
                 let root_schema_b64 = root_schema_b64.as_ref().expect("helper enabled");
                 env_entries.push(format!("AMBER_ROOT_CONFIG_SCHEMA_B64={root_schema_b64}"));
                 env_entries.push(format!(
@@ -923,6 +936,42 @@ fn build_depends_on(any_helper: bool, deps: Vec<(String, &'static str)>) -> Opti
         Some(DependsOn::List(
             deps.into_iter().map(|(name, _)| name).collect(),
         ))
+    }
+}
+
+fn render_compose_image(
+    image: &ProgramImagePlan,
+    root_leaf_by_path: &BTreeMap<&str, &rc::SchemaLeaf>,
+) -> Result<String, String> {
+    match image {
+        ProgramImagePlan::Static(value) => Ok(escape_compose_interpolation(value).into_owned()),
+        ProgramImagePlan::RuntimeTemplate(parts) => {
+            let mut rendered = String::new();
+            for part in parts {
+                match part {
+                    ProgramImagePart::Literal(lit) => {
+                        rendered.push_str(&escape_compose_interpolation(lit));
+                    }
+                    ProgramImagePart::RootConfigPath(path) => {
+                        let leaf = root_leaf_by_path.get(path.as_str()).ok_or_else(|| {
+                            format!(
+                                "runtime program.image path config.{path} is not a root config \
+                                 leaf"
+                            )
+                        })?;
+                        let env_var = rc::env_var_for_path(path).map_err(|err| {
+                            format!("failed to map config path {path} to env var: {err}")
+                        })?;
+                        if leaf.required {
+                            rendered.push_str(&format!("${{{env_var}?missing config.{path}}}"));
+                        } else {
+                            rendered.push_str(&format!("${{{env_var}}}"));
+                        }
+                    }
+                }
+            }
+            Ok(rendered)
+        }
     }
 }
 

--- a/compiler/src/targets/mesh/docker_compose/tests.rs
+++ b/compiler/src/targets/mesh/docker_compose/tests.rs
@@ -414,6 +414,58 @@ fn compose_escapes_entrypoint_dollars() {
 }
 
 #[test]
+fn compose_renders_runtime_program_image_from_root_config() {
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "image": { "type": "string" }
+        },
+        "required": ["image"],
+        "additionalProperties": false
+    });
+    let program = serde_json::from_value(json!({
+        "image": "${config.image}",
+        "entrypoint": ["run"]
+    }))
+    .unwrap();
+
+    let root = Component {
+        id: ComponentId(0),
+        parent: None,
+        moniker: moniker("/"),
+        digest: digest(0),
+        config: None,
+        config_schema: Some(schema),
+        program: Some(program),
+        slots: BTreeMap::new(),
+        provides: BTreeMap::new(),
+        binding_decls: BTreeMap::new(),
+        metadata: None,
+        children: Vec::new(),
+    };
+
+    let scenario = Scenario {
+        root: ComponentId(0),
+        components: vec![Some(root)],
+        bindings: vec![],
+        exports: vec![],
+    };
+
+    let yaml = DockerComposeReporter
+        .emit(&scenario)
+        .expect("compose render ok");
+    let compose = parse_compose(&yaml);
+
+    let service = compose
+        .services
+        .values()
+        .find(|svc| svc.image.contains("AMBER_CONFIG_IMAGE"))
+        .expect("program service should use runtime root config for image");
+    assert_eq!(service.image, "${AMBER_CONFIG_IMAGE?missing config.image}");
+    assert!(!yaml.contains("AMBER_TEMPLATE_SPEC_B64"), "{yaml}");
+}
+
+#[test]
 fn compose_resolves_binding_urls_in_child_config() {
     let server_program = serde_json::from_value(json!({
         "image": "alpine:3.20",

--- a/compiler/src/targets/mesh/kubernetes/mod.rs
+++ b/compiler/src/targets/mesh/kubernetes/mod.rs
@@ -6,16 +6,22 @@ use std::{
 };
 
 use amber_config as rc;
+use amber_manifest::span_for_json_pointer;
 use amber_scenario::{ComponentId, Scenario};
+use miette::{LabeledSpan, NamedSource, SourceSpan};
 pub use resources::*;
 use serde::Serialize;
 
 use crate::{
+    CompileOutput,
     reporter::{Reporter, ReporterError},
     targets::mesh::{
         LOCAL_NETWORK_CIDRS,
         addressing::{Addressing, RouterPortBases, WorkloadId, build_address_plan},
-        config::{ProgramPlan, encode_helper_payload, encode_schema_b64},
+        config::{
+            ProgramImageOrigin, ProgramImagePart, ProgramImagePlan, ProgramPlan,
+            encode_helper_payload, encode_schema_b64,
+        },
         internal_images::resolve_internal_images,
         plan::{MeshOptions, component_label},
     },
@@ -159,6 +165,13 @@ struct ExternalSlotMetadata {
     kind: String,
 }
 
+#[derive(Clone, Debug)]
+struct ProgramImageSource {
+    src: NamedSource<std::sync::Arc<str>>,
+    span: SourceSpan,
+    label: String,
+}
+
 /// Full scenario metadata stored in amber-metadata ConfigMap.
 #[derive(Clone, Debug, Serialize)]
 struct ScenarioMetadata {
@@ -171,9 +184,24 @@ struct ScenarioMetadata {
 
 type KubernetesResult<T> = Result<T, ReporterError>;
 
+pub fn render_kubernetes_with_output(
+    output: &CompileOutput,
+    config: &KubernetesReporterConfig,
+) -> KubernetesResult<KubernetesArtifact> {
+    render_kubernetes_inner(&output.scenario, config, Some(output))
+}
+
 fn render_kubernetes(
     s: &Scenario,
     config: &KubernetesReporterConfig,
+) -> KubernetesResult<KubernetesArtifact> {
+    render_kubernetes_inner(s, config, None)
+}
+
+fn render_kubernetes_inner(
+    s: &Scenario,
+    config: &KubernetesReporterConfig,
+    output: Option<&CompileOutput>,
 ) -> KubernetesResult<KubernetesArtifact> {
     let mesh_plan = crate::targets::mesh::plan::build_mesh_plan(
         s,
@@ -310,8 +338,14 @@ fn render_kubernetes(
     files.insert(PathBuf::from("00-namespace.yaml"), to_yaml(&ns)?);
 
     let root_leaves = &config_plan.root_leaves;
+    let root_leaf_by_path: BTreeMap<&str, &rc::SchemaLeaf> = root_leaves
+        .iter()
+        .map(|leaf| (leaf.path.as_str(), leaf))
+        .collect();
     let program_plans = &config_plan.program_plans;
     let any_helper = config_plan.uses_helper;
+    let any_runtime_image = config_plan.uses_runtime_image;
+    let needs_runtime_root_config = any_helper || any_runtime_image;
 
     let export_ports_by_name = &address_plan.router.export_ports_by_name;
     let router_export_ports = &address_plan.router.export_ports;
@@ -354,12 +388,12 @@ fn render_kubernetes(
         }
     }
 
-    // Build kustomization (will be populated at the end if helper mode is used).
+    // Build kustomization (resource list and generators/replacements are finalized at the end).
     let mut kustomization = Kustomization::new();
     kustomization.namespace = Some(namespace.clone());
 
-    // If any component needs helper, generate root config Secret/ConfigMap and .env templates.
-    if any_helper {
+    // If helper mode or runtime image interpolation is used, generate root config inputs.
+    if needs_runtime_root_config {
         // Separate root leaves into secret and non-secret.
         let (secret_leaves, config_leaves): (Vec<_>, Vec<_>) =
             root_leaves.iter().partition(|l| l.secret);
@@ -441,7 +475,7 @@ fn render_kubernetes(
     //   The helper reads config values from the root config Secret/ConfigMap at
     //   runtime and resolves templates, so secret values are not inlined.
     // The only ConfigMaps generated are amber-metadata and the Kustomize-generated
-    // root config (when helper mode is used).
+    // root config (when helper mode or runtime image interpolation is used).
 
     // Encode root schema for helper (needed for all helper components).
     let root_schema_b64 = if any_helper {
@@ -467,6 +501,16 @@ fn render_kubernetes(
         let labels = component_labels(*id, &cnames.service);
         let program = c.program.as_ref().unwrap();
         let program_plan = program_plans.get(id).unwrap();
+        let component = component_label(s, *id);
+        let image_source = output
+            .and_then(|output| program_image_source(output, s, *id, program_plan.image_origin()));
+        let (program_image, image_source_env_var) = render_kubernetes_image(
+            program_plan.image(),
+            &root_leaf_by_path,
+            &cnames.service,
+            &component,
+            image_source.as_ref(),
+        )?;
 
         // Container ports.
         let mut ports: Vec<ContainerPort> = Vec::new();
@@ -482,7 +526,9 @@ fn render_kubernetes(
 
         // Build container based on program mode.
         let (container, volumes) = match program_plan {
-            ProgramPlan::Direct { entrypoint, env } => {
+            ProgramPlan::Direct {
+                entrypoint, env, ..
+            } => {
                 // Direct mode: use resolved entrypoint and env directly.
                 // Config values are already baked into the entrypoint/env strings,
                 // so we don't need AMBER_CONFIG_* env vars here.
@@ -491,7 +537,7 @@ fn render_kubernetes(
 
                 let container = Container {
                     name: "main".to_string(),
-                    image: program.image.clone(),
+                    image: program_image.clone(),
                     command: entrypoint.clone(),
                     args: Vec::new(),
                     env: container_env,
@@ -507,6 +553,7 @@ fn render_kubernetes(
                 template_spec,
                 component_template,
                 component_schema,
+                ..
             } => {
                 let label = component_label(s, *id);
                 let payload = encode_helper_payload(
@@ -578,7 +625,7 @@ fn render_kubernetes(
 
                 let container = Container {
                     name: "main".to_string(),
-                    image: program.image.clone(),
+                    image: program_image.clone(),
                     command: vec![HELPER_BIN_PATH.to_string(), "run".to_string()],
                     args: Vec::new(),
                     env: container_env,
@@ -597,6 +644,25 @@ fn render_kubernetes(
                 (container, volumes)
             }
         };
+
+        if let Some(env_var) = image_source_env_var {
+            kustomization.replacements.push(Replacement {
+                source: ReplacementSource {
+                    kind: "ConfigMap".to_string(),
+                    name: ROOT_CONFIG_CONFIGMAP_NAME.to_string(),
+                    field_path: format!("data.{env_var}"),
+                },
+                targets: vec![ReplacementTarget {
+                    select: ReplacementSelect {
+                        kind: "Deployment".to_string(),
+                        name: cnames.service.clone(),
+                    },
+                    field_paths: vec![
+                        "spec.template.spec.containers.[name=main].image".to_string(),
+                    ],
+                }],
+            });
+        }
 
         // Add init containers.
         let mut init_containers = Vec::new();
@@ -1151,6 +1217,142 @@ fn render_kubernetes(
 }
 
 // ---- Helper functions ----
+
+fn render_kubernetes_image(
+    image: &ProgramImagePlan,
+    root_leaf_by_path: &BTreeMap<&str, &rc::SchemaLeaf>,
+    service_name: &str,
+    component: &str,
+    image_source: Option<&ProgramImageSource>,
+) -> KubernetesResult<(String, Option<String>)> {
+    match image {
+        ProgramImagePlan::Static(value) => Ok((value.clone(), None)),
+        ProgramImagePlan::RuntimeTemplate(parts) => {
+            let [ProgramImagePart::RootConfigPath(path)] = parts.as_slice() else {
+                return Err(program_image_error(
+                    component,
+                    "resolves to a mixed runtime image template, but kubernetes output only \
+                     supports runtime images that resolve to exactly one concrete config value \
+                     (for example `${config.image}`).",
+                    image_source,
+                ));
+            };
+
+            let leaf = root_leaf_by_path.get(path.as_str()).ok_or_else(|| {
+                program_image_error(
+                    component,
+                    format!(
+                        "references runtime config.{path}, but that path does not resolve to a \
+                         concrete config value"
+                    ),
+                    image_source,
+                )
+            })?;
+            if leaf.secret {
+                return Err(program_image_error(
+                    component,
+                    format!(
+                        "references config.{path}, but kubernetes runtime image interpolation \
+                         does not support secret config values"
+                    ),
+                    image_source,
+                ));
+            }
+
+            let env_var = rc::env_var_for_path(path).map_err(|e| {
+                ReporterError::new(format!(
+                    "failed to map runtime image path config.{path} to env var: {e}"
+                ))
+            })?;
+            Ok((format!("amber-runtime-image-{service_name}"), Some(env_var)))
+        }
+    }
+}
+
+fn program_image_source(
+    output: &CompileOutput,
+    scenario: &Scenario,
+    component: ComponentId,
+    origin: &ProgramImageOrigin,
+) -> Option<ProgramImageSource> {
+    match origin {
+        ProgramImageOrigin::ProgramImage => component_program_image_source(output, component),
+        ProgramImageOrigin::ComponentConfigPath(path) => {
+            component_config_image_source(output, scenario, component, path)
+        }
+    }
+}
+
+fn component_config_image_source(
+    output: &CompileOutput,
+    scenario: &Scenario,
+    component: ComponentId,
+    path: &str,
+) -> Option<ProgramImageSource> {
+    let component = scenario.component(component);
+    let parent = component.parent?;
+    let child_name = component.moniker.local_name()?;
+
+    let provenance = output.provenance.for_component(parent);
+    let url = &provenance.resolved_url;
+    let stored = output.store.get_source(url)?;
+    let root_span: SourceSpan = (0usize, stored.source.len()).into();
+    let child_ptr = json_pointer_escape(child_name);
+    let mut config_ptr = format!("/components/{child_ptr}/config");
+    for segment in path.split('.').filter(|segment| !segment.is_empty()) {
+        config_ptr.push('/');
+        config_ptr.push_str(&json_pointer_escape(segment));
+    }
+    let span = span_for_json_pointer(stored.source.as_ref(), root_span, &config_ptr)?;
+    let src =
+        NamedSource::new(crate::store::display_url(url), stored.source).with_language("json5");
+    Some(ProgramImageSource {
+        src,
+        span,
+        label: "component config image interpolation here".to_string(),
+    })
+}
+
+fn component_program_image_source(
+    output: &CompileOutput,
+    component: ComponentId,
+) -> Option<ProgramImageSource> {
+    let provenance = output.provenance.for_component(component);
+    let url = &provenance.resolved_url;
+    let stored = output.store.get_source(url)?;
+    let program = stored.spans.program.as_ref()?;
+    let root_span: SourceSpan = (0usize, stored.source.len()).into();
+    let span = span_for_json_pointer(stored.source.as_ref(), root_span, "/program/image")
+        .unwrap_or(program.whole);
+    let src =
+        NamedSource::new(crate::store::display_url(url), stored.source).with_language("json5");
+    Some(ProgramImageSource {
+        src,
+        span,
+        label: "program.image interpolation here".to_string(),
+    })
+}
+
+fn json_pointer_escape(segment: &str) -> String {
+    segment.replace('~', "~0").replace('/', "~1")
+}
+
+fn program_image_error(
+    component: &str,
+    message: impl Into<String>,
+    image_source: Option<&ProgramImageSource>,
+) -> ReporterError {
+    let mut error = ReporterError::new(format!("program.image in {component} {}", message.into()));
+    if let Some(image_source) = image_source {
+        error = error
+            .with_source_code(image_source.src.clone())
+            .with_labels(vec![LabeledSpan::new_primary_with_span(
+                Some(image_source.label.clone()),
+                image_source.span,
+            )]);
+    }
+    error
+}
 
 fn generate_namespace_name(s: &Scenario) -> String {
     let root = s.component(s.root);

--- a/compiler/src/targets/mesh/kubernetes/resources.rs
+++ b/compiler/src/targets/mesh/kubernetes/resources.rs
@@ -605,6 +605,9 @@ pub struct Kustomization {
     /// Secret generators.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub secret_generator: Vec<SecretGenerator>,
+    /// Replacements applied to emitted resources.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub replacements: Vec<Replacement>,
     /// Namespace to apply to all resources.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
@@ -661,4 +664,35 @@ pub struct SecretGenerator {
 pub struct GeneratorOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub disable_name_suffix_hash: Option<bool>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Replacement {
+    pub source: ReplacementSource,
+    pub targets: Vec<ReplacementTarget>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplacementSource {
+    pub kind: String,
+    pub name: String,
+    #[serde(rename = "fieldPath")]
+    pub field_path: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplacementTarget {
+    pub select: ReplacementSelect,
+    #[serde(rename = "fieldPaths")]
+    pub field_paths: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplacementSelect {
+    pub kind: String,
+    pub name: String,
 }

--- a/compiler/src/targets/mesh/kubernetes/tests.rs
+++ b/compiler/src/targets/mesh/kubernetes/tests.rs
@@ -468,6 +468,267 @@ fn kubernetes_emits_router_for_external_slots() {
 }
 
 #[test]
+fn kubernetes_renders_static_program_image_from_static_component_config() {
+    let dir = tempdir().expect("temp dir");
+    let root_path = dir.path().join("root.json5");
+    let child_path = dir.path().join("child.json5");
+
+    fs::write(
+        &root_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          components: {
+            child: {
+              manifest: "./child.json5",
+              config: { image: "busybox:1.36.1" }
+            },
+          },
+        }
+        "#,
+    )
+    .expect("write root manifest");
+
+    fs::write(
+        &child_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          config_schema: {
+            type: "object",
+            properties: { image: { type: "string" } },
+            required: ["image"],
+            additionalProperties: false,
+          },
+          program: {
+            image: "${config.image}",
+            entrypoint: ["child"],
+          },
+        }
+        "#,
+    )
+    .expect("write child manifest");
+
+    let compiler = Compiler::new(Resolver::new(), DigestStore::default());
+    let opts = CompileOptions {
+        optimize: OptimizeOptions { dce: false },
+        ..Default::default()
+    };
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let output = rt
+        .block_on(compiler.compile(ManifestRef::from_url(file_url(&root_path)), opts))
+        .expect("compile scenario");
+
+    let reporter = KubernetesReporter {
+        config: KubernetesReporterConfig {
+            disable_networkpolicy_check: true,
+        },
+    };
+    let artifact = reporter
+        .emit(&output.scenario)
+        .expect("render kubernetes output");
+
+    let child_deploy = artifact
+        .files
+        .get(&PathBuf::from("03-deployments/c1-child.yaml"))
+        .expect("child deployment");
+    assert!(
+        child_deploy.contains("image: busybox:1.36.1"),
+        "{child_deploy}"
+    );
+
+    let kustomization = artifact
+        .files
+        .get(&PathBuf::from("kustomization.yaml"))
+        .expect("kustomization");
+    assert!(!kustomization.contains("replacements:"), "{kustomization}");
+    assert!(
+        !artifact
+            .files
+            .contains_key(&PathBuf::from("root-config.env")),
+        "static image interpolation should not require runtime root config"
+    );
+}
+
+#[test]
+fn kubernetes_supports_runtime_program_image_when_whole_image_is_config_leaf() {
+    let dir = tempdir().expect("temp dir");
+    let root_path = dir.path().join("root.json5");
+    let child_path = dir.path().join("child.json5");
+
+    fs::write(
+        &root_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          config_schema: {
+            type: "object",
+            properties: { child_image: { type: "string" } },
+            required: ["child_image"],
+            additionalProperties: false,
+          },
+          components: {
+            child: {
+              manifest: "./child.json5",
+              config: { image: "${config.child_image}" }
+            },
+          },
+        }
+        "#,
+    )
+    .expect("write root manifest");
+
+    fs::write(
+        &child_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          config_schema: {
+            type: "object",
+            properties: { image: { type: "string" } },
+            required: ["image"],
+            additionalProperties: false,
+          },
+          program: {
+            image: "${config.image}",
+            entrypoint: ["child"],
+          },
+        }
+        "#,
+    )
+    .expect("write child manifest");
+
+    let compiler = Compiler::new(Resolver::new(), DigestStore::default());
+    let opts = CompileOptions {
+        optimize: OptimizeOptions { dce: false },
+        ..Default::default()
+    };
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let output = rt
+        .block_on(compiler.compile(ManifestRef::from_url(file_url(&root_path)), opts))
+        .expect("compile scenario");
+
+    let reporter = KubernetesReporter {
+        config: KubernetesReporterConfig {
+            disable_networkpolicy_check: true,
+        },
+    };
+    let artifact = reporter
+        .emit(&output.scenario)
+        .expect("render kubernetes output");
+
+    let child_deploy = artifact
+        .files
+        .get(&PathBuf::from("03-deployments/c1-child.yaml"))
+        .expect("child deployment");
+    assert!(
+        child_deploy.contains("image: amber-runtime-image-c1-child"),
+        "{child_deploy}"
+    );
+    assert!(
+        !child_deploy.contains("AMBER_TEMPLATE_SPEC_B64"),
+        "{child_deploy}"
+    );
+
+    let kustomization = artifact
+        .files
+        .get(&PathBuf::from("kustomization.yaml"))
+        .expect("kustomization");
+    assert!(kustomization.contains("replacements:"), "{kustomization}");
+    assert!(
+        kustomization.contains("name: amber-root-config"),
+        "{kustomization}"
+    );
+    assert!(
+        kustomization.contains("fieldPath: data.AMBER_CONFIG_CHILD_IMAGE"),
+        "{kustomization}"
+    );
+    assert!(
+        kustomization.contains("spec.template.spec.containers.[name=main].image"),
+        "{kustomization}"
+    );
+
+    let root_env = artifact
+        .files
+        .get(&PathBuf::from("root-config.env"))
+        .expect("runtime image should generate root-config.env");
+    assert!(root_env.contains("AMBER_CONFIG_CHILD_IMAGE="), "{root_env}");
+}
+
+#[test]
+fn kubernetes_rejects_runtime_program_image_templates() {
+    let dir = tempdir().expect("temp dir");
+    let root_path = dir.path().join("root.json5");
+    let child_path = dir.path().join("child.json5");
+
+    fs::write(
+        &root_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          config_schema: {
+            type: "object",
+            properties: { tag: { type: "string" } },
+            required: ["tag"],
+            additionalProperties: false,
+          },
+          components: {
+            child: {
+              manifest: "./child.json5",
+              config: { image: "busybox:${config.tag}" }
+            },
+          },
+        }
+        "#,
+    )
+    .expect("write root manifest");
+
+    fs::write(
+        &child_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          config_schema: {
+            type: "object",
+            properties: { image: { type: "string" } },
+            required: ["image"],
+            additionalProperties: false,
+          },
+          program: {
+            image: "${config.image}",
+            entrypoint: ["child"],
+          },
+        }
+        "#,
+    )
+    .expect("write child manifest");
+
+    let compiler = Compiler::new(Resolver::new(), DigestStore::default());
+    let opts = CompileOptions {
+        optimize: OptimizeOptions { dce: false },
+        ..Default::default()
+    };
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let output = rt
+        .block_on(compiler.compile(ManifestRef::from_url(file_url(&root_path)), opts))
+        .expect("compile scenario");
+
+    let reporter = KubernetesReporter {
+        config: KubernetesReporterConfig {
+            disable_networkpolicy_check: true,
+        },
+    };
+    let err = reporter
+        .emit(&output.scenario)
+        .expect_err("mixed runtime image should fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("resolves to a mixed runtime image template"),
+        "{msg}"
+    );
+}
+
+#[test]
 #[ignore = "requires docker + kind + kubectl + curl; run manually"]
 fn kubernetes_smoke_config_roundtrip() {
     if !k8s_smoke_preflight() {

--- a/manifest/README.md
+++ b/manifest/README.md
@@ -201,9 +201,9 @@ program: {
 }
 ```
 
-### Interpolation in `args` and `env`
+### Interpolation in `image`, `args`, and `env`
 
-`args` elements and `env` values support `${...}` interpolation.
+`image`, `args` elements, and `env` values support `${...}` interpolation.
 
 Supported sources:
 

--- a/manifest/src/lint.rs
+++ b/manifest/src/lint.rs
@@ -124,7 +124,7 @@ pub enum ManifestLint {
 fn add_program_slot_uses<'a>(
     manifest: &'a Manifest,
     used_slots: &mut BTreeSet<&'a SlotName>,
-    value: &'a InterpolatedString,
+    value: &InterpolatedString,
 ) -> bool {
     let used_all = value.visit_slot_uses(|slot_name| {
         if let Some((slot_key, _)) = manifest.slots().get_key_value(slot_name) {
@@ -176,6 +176,9 @@ fn collect_config_uses(manifest: &Manifest) -> ConfigUses {
     let mut uses = ConfigUses::default();
 
     if let Some(program) = manifest.program() {
+        if let Ok(image) = program.image.parse::<InterpolatedString>() {
+            collect_config_uses_from_interpolated(&image, &mut uses);
+        }
         for arg in &program.args.0 {
             collect_config_uses_from_interpolated(arg, &mut uses);
         }
@@ -254,10 +257,15 @@ pub fn lint_manifest(
     let mut program_used_slots = BTreeSet::new();
     if let Some(program) = manifest.program() {
         let mut used_all = false;
-        for arg in &program.args.0 {
-            used_all = add_program_slot_uses(manifest, &mut program_used_slots, arg);
-            if used_all {
-                break;
+        if let Ok(image) = program.image.parse::<InterpolatedString>() {
+            used_all = add_program_slot_uses(manifest, &mut program_used_slots, &image);
+        }
+        if !used_all {
+            for arg in &program.args.0 {
+                used_all = add_program_slot_uses(manifest, &mut program_used_slots, arg);
+                if used_all {
+                    break;
+                }
             }
         }
         if !used_all {

--- a/manifest/src/manifest/tests.rs
+++ b/manifest/src/manifest/tests.rs
@@ -80,6 +80,45 @@ fn program_args_string_sugar_splits() {
 }
 
 #[test]
+fn program_image_supports_interpolation_syntax() {
+    let m: Manifest = r#"
+        {
+          manifest_version: "0.1.0",
+          config_schema: {
+            type: "object",
+            properties: { image: { type: "string" } },
+          },
+          program: {
+            image: "${config.image}",
+            entrypoint: ["x"],
+          }
+        }
+        "#
+    .parse()
+    .unwrap();
+
+    let program = m.program.as_ref().expect("program should exist");
+    assert_eq!(program.image, "${config.image}");
+}
+
+#[test]
+fn invalid_program_image_interpolation_syntax_errors() {
+    let err = r#"
+        {
+          manifest_version: "0.1.0",
+          program: {
+            image: "${config.image",
+            entrypoint: ["x"],
+          }
+        }
+        "#
+    .parse::<Manifest>()
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("invalid interpolation"), "{msg}");
+}
+
+#[test]
 fn binding_sugar_forms_parse() {
     let m: Manifest = r##"
         {

--- a/manifest/src/schema.rs
+++ b/manifest/src/schema.rs
@@ -33,6 +33,7 @@ use crate::{
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub struct Program {
+    #[serde(deserialize_with = "deserialize_program_image")]
     pub image: String,
     #[serde(default, alias = "entrypoint")]
     #[builder(default)]
@@ -43,6 +44,17 @@ pub struct Program {
     pub env: BTreeMap<String, InterpolatedString>,
     #[serde(default)]
     pub network: Option<Network>,
+}
+
+fn deserialize_program_image<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let image = String::deserialize(deserializer)?;
+    image
+        .parse::<InterpolatedString>()
+        .map_err(serde::de::Error::custom)?;
+    Ok(image)
 }
 
 #[derive(


### PR DESCRIPTION
This PR adds first-class interpolation support for `program.image` and threads it through manifest validation, compiler analysis, and mesh target rendering.

- Adds program.image interpolation parsing/validation in the manifest schema and updates docs.
- Extends binding/config/slot validation, linker checks, linting, and DCE slot-use tracking to include program.image.
- Updates mesh config planning to distinguish helper-required runtime templates (entrypoint/env) from runtime-derived images.
- Adds runtime image handling for Docker Compose and Kubernetes (including Kubernetes replacement-based image injection and clear rejection of unsupported runtime image templates).
- Adds coverage with new manifest tests, mesh target tests, and a CLI UI test for Kubernetes runtime-template rejection.