### PR TITLE
compiler: allow externalized slots to be liveness roots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 * Use crates from crates.io when it saves complexity or lines of code, but only when the crate is well-maintained and very widely used in the ecosystem OR already in use somewhere in this workspace as a direct or indirect dependency.
 * Add a dependency to the cargo workspace root if and only if it is used by more than one crate in the workspace.
 * NEVER attempt to preserve backwards compatibility or preserve "legacy" interfaces unless explicitly requested. You can assume that there are no versioning or compatibility guarantees.
-* Run `cargo test`, `cargo clippy`, and cargo fmt` after any non-trivial change to the Rust code.
+* Run `cargo test --workspace --all-features`, `cargo clippy --all-targets`, and cargo fmt` after any non-trivial change to the Rust code.
 * There may be other agents working on this repo concurrently. Don't fret if you see files created or changed that you didn't create or change yourself. Just ignore them and carry on unless they directly conflict with your work, in which case stop and seek guidance.
 * Always keep READMEs up-to-date with information that is helpful to expert developers who are not familiar with Amber. When making updates to the READMEs, don't just find and replace isolated snippets–ensure that each line, paragraph, section, etc. is useful in the context of the whole document.
 * Make error messages and spans as helpful to devs as possible. Rust error messaging is a great example of usability

--- a/cli/tests/ui/slot_interpolation_storage.stderr
+++ b/cli/tests/ui/slot_interpolation_storage.stderr
@@ -9,21 +9,4 @@ compiler::invalid_slots_interpolation
  9 |     ],
    `----
   help: Mount the storage slot with `program.mounts: [{ from: "slots.<slot>", path: "/var/lib/app" }]` instead of using `${slots...}`.
-manifest::unused_program
-
-  ! program is never referenced by bindings or exports (in component /)
-    ,-[<CARGO_MANIFEST_DIR>/tests/ui/slot_interpolation_storage.json5:3:12]
-  2 |       manifest_version: "0.1.0",
-  3 | ,->   program: {
-  4 | |       image: "busybox:1.36.1",
-  5 | |       entrypoint: [
-  6 | |         "sh",
-  7 | |         "-lc",
-  8 | |         "echo ${slots.state.url}",
-  9 | |       ],
- 10 | |->   },
-    : `---- unused `program`
- 11 |       slots: {
-    `----
-  help: Remove the `program` block if it is not needed, or export/bind one of its provides.
 Error:   × check failed

--- a/cli/tests/ui/slot_interpolation_storage_slot.stderr
+++ b/cli/tests/ui/slot_interpolation_storage_slot.stderr
@@ -9,20 +9,4 @@ compiler::invalid_slots_interpolation
  11 |     },
     `----
   help: Mount the storage slot with `program.mounts: [{ from: "slots.<slot>", path: "/var/lib/app" }]` instead of using `${slots...}`.
-manifest::unused_program
-
-  ! program is never referenced by bindings or exports (in component /)
-    ,-[<CARGO_MANIFEST_DIR>/tests/ui/slot_interpolation_storage_slot.json5:6:12]
-  5 |       },
-  6 | ,->   program: {
-  7 | |       image: "x",
-  8 | |       entrypoint: ["x"],
-  9 | |       env: {
- 10 | |         STATE_URL: "${slots.state.url}",
- 11 | |       },
- 12 | |->   },
-    : `---- unused `program`
- 13 |     }
-    `----
-  help: Remove the `program` block if it is not needed, or export/bind one of its provides.
 Error:   × check failed

--- a/compiler/scenario/src/lib.rs
+++ b/compiler/scenario/src/lib.rs
@@ -67,7 +67,7 @@ impl AsRef<str> for Moniker {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Scenario {
     pub root: ComponentId,
     pub components: Vec<Option<Component>>,
@@ -199,7 +199,7 @@ impl Scenario {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Component {
     pub id: ComponentId,
     pub parent: Option<ComponentId>,
@@ -278,7 +278,7 @@ pub struct SlotRef {
     pub name: String,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct BindingEdge {
     pub from: BindingFrom,
     pub to: SlotRef,

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -11,7 +11,7 @@ use amber_manifest::{
     lint::{ManifestLint, lint_manifest},
 };
 use amber_resolver::Resolver;
-use amber_scenario::{ComponentId, Scenario};
+use amber_scenario::{BindingFrom, ComponentId, Scenario};
 use miette::{Diagnostic, Report};
 use thiserror::Error;
 
@@ -254,6 +254,7 @@ fn collect_manifest_diagnostics(
 ) -> Vec<Report> {
     let mut diagnostics = Vec::new();
     let optional_slots = effective_optional_slots_by_component(scenario, provenance);
+    let externally_rooted_programs = externally_rooted_programs_by_component(scenario, provenance);
 
     for (_, component) in scenario.components_iter() {
         let manifest = store
@@ -274,7 +275,9 @@ fn collect_manifest_diagnostics(
         diagnostics.extend(
             lints
                 .into_iter()
-                .filter(|lint| !suppress_manifest_unused_slot_lint(lint, &optional_slots))
+                .filter(|lint| {
+                    !suppress_manifest_lint(lint, &optional_slots, &externally_rooted_programs)
+                })
                 .map(Report::new),
         );
     }
@@ -318,20 +321,22 @@ fn collect_tree_node_diagnostics(
     }
 }
 
-fn suppress_manifest_unused_slot_lint(
+fn suppress_manifest_lint(
     lint: &ManifestLint,
     optional_slots_by_component: &BTreeMap<String, BTreeSet<String>>,
+    externally_rooted_programs: &BTreeSet<String>,
 ) -> bool {
-    let ManifestLint::UnusedSlot {
-        name, component, ..
-    } = lint
-    else {
-        return false;
-    };
-
-    optional_slots_by_component
-        .get(component)
-        .is_some_and(|slots| slots.contains(name))
+    match lint {
+        ManifestLint::UnusedSlot {
+            name, component, ..
+        } => optional_slots_by_component
+            .get(component)
+            .is_some_and(|slots| slots.contains(name)),
+        ManifestLint::UnusedProgram { component, .. } => {
+            externally_rooted_programs.contains(component)
+        }
+        _ => false,
+    }
 }
 
 fn effective_optional_slots_by_component(
@@ -364,6 +369,43 @@ fn effective_optional_slots_by_component(
         out.entry(component_path)
             .or_insert_with(BTreeSet::new)
             .insert(binding.to.name.clone());
+    }
+
+    out
+}
+
+fn externally_rooted_programs_by_component(
+    scenario: &Scenario,
+    provenance: &Provenance,
+) -> BTreeSet<String> {
+    let used_slots_by_component: Vec<BTreeSet<String>> = scenario
+        .components
+        .iter()
+        .map(|component| {
+            component
+                .as_ref()
+                .map(|component| {
+                    mir::collect_program_used_slots(component)
+                        .into_iter()
+                        .collect()
+                })
+                .unwrap_or_default()
+        })
+        .collect();
+
+    let mut out = BTreeSet::new();
+    for binding in &scenario.bindings {
+        let BindingFrom::External(_) = &binding.from else {
+            continue;
+        };
+        if used_slots_by_component[binding.to.component.0].contains(binding.to.name.as_str()) {
+            out.insert(
+                provenance
+                    .for_component(binding.to.component)
+                    .authored_moniker
+                    .to_string(),
+            );
+        }
     }
 
     out

--- a/compiler/src/mir.rs
+++ b/compiler/src/mir.rs
@@ -529,6 +529,7 @@ struct DceResults {
 struct DceSolver<'a> {
     scenario: &'a Scenario,
     incoming: Vec<Vec<usize>>,
+    program_used_slots: Vec<HashSet<String>>,
     keep_components: Vec<bool>,
     live_programs: Vec<bool>,
     live_slots: HashSet<CapKey>,
@@ -551,11 +552,22 @@ impl<'a> DceSolver<'a> {
             }
             incoming[binding.to.component.0].push(idx);
         }
+        let program_used_slots = scenario
+            .components
+            .iter()
+            .map(|component| {
+                component
+                    .as_ref()
+                    .map(|component| collect_program_used_slots(component).into_iter().collect())
+                    .unwrap_or_default()
+            })
+            .collect();
 
         let n = scenario.components.len();
         Self {
             scenario,
             incoming,
+            program_used_slots,
             keep_components: vec![false; n],
             live_programs: vec![false; n],
             live_slots: HashSet::new(),
@@ -570,6 +582,7 @@ impl<'a> DceSolver<'a> {
         for export in &self.scenario.exports {
             self.mark_provide(export.from.component.0, &export.from.name);
         }
+        self.seed_externally_rooted_programs();
 
         while let Some(item) = self.work.pop_front() {
             match item {
@@ -587,6 +600,17 @@ impl<'a> DceSolver<'a> {
             live_provides: self.live_provides,
             live_resources: self.live_resources,
             live_bindings: self.live_bindings,
+        }
+    }
+
+    fn seed_externally_rooted_programs(&mut self) {
+        for binding in &self.scenario.bindings {
+            let BindingFrom::External(_) = &binding.from else {
+                continue;
+            };
+            if self.program_used_slots[binding.to.component.0].contains(binding.to.name.as_str()) {
+                self.mark_program_live(binding.to.component.0);
+            }
         }
     }
 
@@ -740,7 +764,7 @@ fn is_live_capability(live: &HashSet<CapKey>, component: usize, name: &str) -> b
     })
 }
 
-fn collect_program_used_slots(component: &amber_scenario::Component) -> Vec<String> {
+pub(crate) fn collect_program_used_slots(component: &amber_scenario::Component) -> Vec<String> {
     let Some(program) = component.program.as_ref() else {
         return Vec::new();
     };
@@ -821,6 +845,7 @@ fn compute_keep_set(
 
 #[cfg(test)]
 mod tests {
+    use amber_manifest::SlotDecl;
     use amber_scenario::{Moniker, ProvideRef};
 
     use super::*;
@@ -891,6 +916,103 @@ mod tests {
         assert_eq!(rewritten.bindings.len(), 2);
         assert_eq!(rewritten.bindings[0].to.name, "upstream");
         assert_eq!(rewritten.bindings[1].to.name, "upstream");
+    }
+
+    fn slot_decl(kind: &str, optional: bool, multiple: bool) -> SlotDecl {
+        let mut value = serde_json::json!({ "kind": kind });
+        if optional {
+            value["optional"] = serde_json::Value::Bool(true);
+        }
+        if multiple {
+            value["multiple"] = serde_json::Value::Bool(true);
+        }
+        serde_json::from_value(value).expect("slot decl")
+    }
+
+    #[test]
+    fn collect_program_used_slots_covers_program_surface() {
+        let program = serde_json::from_value(serde_json::json!({
+            "path": "${slots.runner.path}",
+            "args": [
+                "${slots.api.url}",
+                { "when": "slots.gate", "argv": ["--gate"] },
+                { "each": "slots.peers", "argv": ["--peer", "${item.url}"] },
+            ],
+            "env": {
+                "HEADERS_URL": "${slots.headers.url}",
+                "PEERS": {
+                    "each": "slots.peers",
+                    "value": "${item.url}",
+                    "join": ","
+                }
+            },
+            "mounts": [
+                { "path": "/var/lib/state", "from": "slots.state" }
+            ]
+        }))
+        .expect("program");
+
+        let mut component = component(0, "/");
+        component.program = Some(program);
+        component
+            .slots
+            .insert("api".to_string(), slot_decl("http", false, false));
+        component
+            .slots
+            .insert("gate".to_string(), slot_decl("http", true, false));
+        component
+            .slots
+            .insert("headers".to_string(), slot_decl("http", false, false));
+        component
+            .slots
+            .insert("peers".to_string(), slot_decl("http", true, true));
+        component
+            .slots
+            .insert("runner".to_string(), slot_decl("storage", false, false));
+        component
+            .slots
+            .insert("state".to_string(), slot_decl("storage", false, false));
+        component
+            .slots
+            .insert("unused".to_string(), slot_decl("http", false, false));
+
+        assert_eq!(
+            collect_program_used_slots(&component),
+            vec![
+                "api".to_string(),
+                "gate".to_string(),
+                "headers".to_string(),
+                "peers".to_string(),
+                "runner".to_string(),
+                "state".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn collect_program_used_slots_returns_all_slots_for_whole_slots_interpolation() {
+        let program = serde_json::from_value(serde_json::json!({
+            "image": "runner",
+            "entrypoint": ["runner"],
+            "env": {
+                "ALL_SLOTS": "${slots}"
+            }
+        }))
+        .expect("program");
+
+        let mut component = component(0, "/");
+        component.program = Some(program);
+        component
+            .slots
+            .insert("admin".to_string(), slot_decl("http", false, false));
+        component
+            .slots
+            .insert("api".to_string(), slot_decl("http", false, false));
+
+        assert_eq!(
+            collect_program_used_slots(&component),
+            vec!["admin".to_string(), "api".to_string()]
+        );
     }
 }
 

--- a/compiler/src/mir/dce_tests.rs
+++ b/compiler/src/mir/dce_tests.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, sync::Arc};
 
-use amber_manifest::{FrameworkCapabilityName, Manifest, ProvideDecl};
+use amber_manifest::{FrameworkCapabilityName, Manifest, Program, ProvideDecl, SlotDecl};
 use amber_scenario::{
     BindingEdge, BindingFrom, Component, ComponentId, Moniker, ProvideRef, ResourceDecl,
     ResourceRef, Scenario, ScenarioExport, SlotRef, StorageResourceParams,
@@ -123,6 +123,48 @@ fn storage_resource_decl(size: Option<&str>) -> ResourceDecl {
         None => json!({ "kind": "storage" }),
     };
     serde_json::from_value(value).expect("storage resource decl")
+}
+
+fn manifest_slot(kind: &str, optional: bool, multiple: bool) -> SlotDecl {
+    let mut value = json!({ "kind": kind });
+    if optional {
+        value["optional"] = serde_json::Value::Bool(true);
+    }
+    if multiple {
+        value["multiple"] = serde_json::Value::Bool(true);
+    }
+    serde_json::from_value(value).expect("slot decl")
+}
+
+fn externally_rooted_child_scenario(
+    slot_name: &str,
+    slot_decl: SlotDecl,
+    child_program: Program,
+) -> Scenario {
+    let mut root = component(0, "/");
+    root.slots.insert(slot_name.to_string(), slot_decl.clone());
+    root.children.push(ComponentId(1));
+
+    let mut child = component(1, "/child");
+    child.parent = Some(ComponentId(0));
+    child.program = Some(child_program);
+    child.slots.insert(slot_name.to_string(), slot_decl);
+
+    let mut scenario = Scenario {
+        root: ComponentId(0),
+        components: vec![Some(root), Some(child)],
+        bindings: vec![external_binding(0, slot_name, 1, slot_name, true)],
+        exports: Vec::new(),
+    };
+    scenario.normalize_order();
+    scenario
+}
+
+fn assert_dce_idempotent(scenario: Scenario) -> Scenario {
+    let once = dce_only(scenario);
+    let twice = dce_only(once.clone());
+    assert_eq!(once, twice, "dce changed the scenario on a second pass");
+    once
 }
 
 fn external_binding(
@@ -1218,4 +1260,492 @@ fn dce_keeps_live_external_root_slot_used_in_env_when_condition() {
         ),
         "expected external binding from root.white to remain"
     );
+}
+
+#[test]
+fn dce_keeps_externally_rooted_child_program_without_exports() {
+    let slot_decl = manifest_slot("http", false, false);
+    let child_program = serde_json::from_value(json!({
+        "image": "child",
+        "entrypoint": ["child"],
+        "env": { "API_URL": "${slots.api.url}" },
+    }))
+    .expect("program");
+
+    let mut root = component(0, "/");
+    root.slots.insert("api".to_string(), slot_decl.clone());
+    root.children.push(ComponentId(1));
+
+    let mut child = component(1, "/child");
+    child.parent = Some(ComponentId(0));
+    child.program = Some(child_program);
+    child.slots.insert("api".to_string(), slot_decl);
+
+    let scenario = Scenario {
+        root: ComponentId(0),
+        components: vec![Some(root), Some(child)],
+        bindings: vec![external_binding(0, "api", 1, "api", true)],
+        exports: Vec::new(),
+    };
+
+    let scenario = assert_dce_idempotent(scenario);
+    let root_after = scenario.component(ComponentId(0));
+    let child_after = scenario
+        .components
+        .get(1)
+        .and_then(|component| component.as_ref())
+        .expect("child should remain live");
+
+    assert!(
+        child_after.program.is_some(),
+        "externally rooted child program must remain"
+    );
+    assert!(
+        root_after.slots.contains_key("api"),
+        "external root slot must remain when it roots a child program"
+    );
+    assert_eq!(scenario.bindings.len(), 1, "external binding should remain");
+    assert!(
+        matches!(
+            &scenario.bindings[0].from,
+            BindingFrom::External(slot) if slot.component == ComponentId(0) && slot.name == "api"
+        ),
+        "expected external binding from root.api to remain"
+    );
+}
+
+#[test]
+fn dce_keeps_externally_rooted_root_program_without_exports() {
+    let slot_decl = manifest_slot("http", false, false);
+    let root_program = serde_json::from_value(json!({
+        "image": "root",
+        "entrypoint": ["root"],
+        "env": { "API_URL": "${slots.api.url}" },
+    }))
+    .expect("program");
+
+    let mut root = component(0, "/");
+    root.program = Some(root_program);
+    root.slots.insert("api".to_string(), slot_decl);
+
+    let scenario = Scenario {
+        root: ComponentId(0),
+        components: vec![Some(root)],
+        bindings: vec![external_binding(0, "api", 0, "api", true)],
+        exports: Vec::new(),
+    };
+
+    let scenario = assert_dce_idempotent(scenario);
+    let root_after = scenario.component(ComponentId(0));
+
+    assert!(
+        root_after.program.is_some(),
+        "externally rooted root program must remain"
+    );
+    assert!(
+        root_after.slots.contains_key("api"),
+        "root external slot must remain when the root program consumes it"
+    );
+    assert_eq!(
+        scenario.bindings.len(),
+        1,
+        "synthetic self external binding should remain"
+    );
+    assert!(
+        matches!(
+            &scenario.bindings[0].from,
+            BindingFrom::External(slot) if slot.component == ComponentId(0) && slot.name == "api"
+        ),
+        "expected self external binding from root.api to remain"
+    );
+}
+
+#[test]
+fn dce_prunes_unused_external_binding_without_exports() {
+    let slot_decl = manifest_slot("http", false, false);
+    let child_program = serde_json::from_value(json!({
+        "image": "child",
+        "entrypoint": ["child"],
+    }))
+    .expect("program");
+
+    let mut root = component(0, "/");
+    root.slots.insert("api".to_string(), slot_decl.clone());
+    root.children.push(ComponentId(1));
+
+    let mut child = component(1, "/child");
+    child.parent = Some(ComponentId(0));
+    child.program = Some(child_program);
+    child.slots.insert("api".to_string(), slot_decl);
+
+    let scenario = Scenario {
+        root: ComponentId(0),
+        components: vec![Some(root), Some(child)],
+        bindings: vec![external_binding(0, "api", 1, "api", true)],
+        exports: Vec::new(),
+    };
+
+    let scenario = assert_dce_idempotent(scenario);
+    let root_after = scenario.component(ComponentId(0));
+
+    assert!(
+        scenario.components[1].is_none(),
+        "child should be pruned when the external-bound slot is never used by its program"
+    );
+    assert!(
+        !root_after.slots.contains_key("api"),
+        "dead external root slot should be pruned when nothing live consumes it"
+    );
+    assert!(
+        scenario.bindings.is_empty(),
+        "dead external binding should be removed"
+    );
+}
+
+#[test]
+fn dce_keeps_internal_dependencies_of_externally_rooted_program_without_exports() {
+    let slot_http = manifest_slot("http", false, false);
+    let provide_http: amber_manifest::ProvideDecl =
+        serde_json::from_value(json!({ "kind": "http", "endpoint": "admin" }))
+            .expect("provide decl");
+    let consumer_program = serde_json::from_value(json!({
+        "image": "consumer",
+        "entrypoint": ["consumer"],
+        "env": {
+            "API_URL": "${slots.api.url}",
+            "ADMIN_URL": "${slots.admin.url}",
+        },
+    }))
+    .expect("program");
+    let provider_program = serde_json::from_value(json!({
+        "image": "provider",
+        "entrypoint": ["provider"],
+        "network": { "endpoints": [{ "name": "admin", "port": 9000 }] },
+    }))
+    .expect("program");
+
+    let mut root = component(0, "/");
+    root.slots.insert("api".to_string(), slot_http.clone());
+    root.children.extend([ComponentId(1), ComponentId(2)]);
+
+    let mut consumer = component(1, "/consumer");
+    consumer.parent = Some(ComponentId(0));
+    consumer.program = Some(consumer_program);
+    consumer.slots.insert("api".to_string(), slot_http.clone());
+    consumer
+        .slots
+        .insert("admin".to_string(), slot_http.clone());
+
+    let mut provider = component(2, "/provider");
+    provider.parent = Some(ComponentId(0));
+    provider.program = Some(provider_program);
+    provider.provides.insert("admin".to_string(), provide_http);
+
+    let scenario = Scenario {
+        root: ComponentId(0),
+        components: vec![Some(root), Some(consumer), Some(provider)],
+        bindings: vec![
+            external_binding(0, "api", 1, "api", true),
+            component_binding(2, "admin", 1, "admin"),
+        ],
+        exports: Vec::new(),
+    };
+
+    let scenario = assert_dce_idempotent(scenario);
+
+    assert!(
+        scenario
+            .components
+            .iter()
+            .flatten()
+            .any(|component| component.moniker.local_name() == Some("consumer")),
+        "externally rooted consumer must remain"
+    );
+    assert!(
+        scenario
+            .components
+            .iter()
+            .flatten()
+            .any(|component| component.moniker.local_name() == Some("provider")),
+        "provider needed by an externally rooted consumer must remain"
+    );
+    assert!(scenario.bindings.iter().any(|edge| {
+        matches!(
+            &edge.from,
+            BindingFrom::External(slot)
+                if slot.component == ComponentId(0) && slot.name == "api"
+        ) && edge.to.component == ComponentId(1)
+            && edge.to.name == "api"
+    }));
+    assert!(scenario.bindings.iter().any(|edge| {
+        matches!(&edge.from, BindingFrom::Component(from) if from.component == ComponentId(2) && from.name == "admin")
+            && edge.to.component == ComponentId(1)
+            && edge.to.name == "admin"
+    }));
+}
+
+#[test]
+fn dce_keeps_externally_rooted_program_when_slot_is_only_used_in_when_without_exports() {
+    let slot_decl = manifest_slot("http", true, false);
+    let child_program = serde_json::from_value(json!({
+        "image": "child",
+        "entrypoint": [
+            "child",
+            { "when": "slots.api", "argv": ["--api"] }
+        ],
+    }))
+    .expect("program");
+
+    let mut root = component(0, "/");
+    root.slots.insert("api".to_string(), slot_decl.clone());
+    root.children.push(ComponentId(1));
+
+    let mut child = component(1, "/child");
+    child.parent = Some(ComponentId(0));
+    child.program = Some(child_program);
+    child.slots.insert("api".to_string(), slot_decl);
+
+    let scenario = Scenario {
+        root: ComponentId(0),
+        components: vec![Some(root), Some(child)],
+        bindings: vec![external_binding(0, "api", 1, "api", true)],
+        exports: Vec::new(),
+    };
+
+    let scenario = assert_dce_idempotent(scenario);
+
+    assert!(
+        scenario
+            .components
+            .iter()
+            .flatten()
+            .any(|component| component.moniker.local_name() == Some("child")),
+        "slot use in `when` should be enough to root the child program from an external slot"
+    );
+    assert_eq!(scenario.bindings.len(), 1, "external binding should remain");
+}
+
+#[test]
+fn dce_keeps_externally_rooted_program_when_slot_is_only_used_in_repeated_entrypoint_each_without_exports()
+ {
+    let child_program = serde_json::from_value(json!({
+        "image": "child",
+        "entrypoint": [
+            "child",
+            {
+                "each": "slots.api",
+                "argv": ["--api", "${item.url}"]
+            }
+        ],
+    }))
+    .expect("program");
+
+    let scenario =
+        externally_rooted_child_scenario("api", manifest_slot("http", true, true), child_program);
+    let scenario = assert_dce_idempotent(scenario);
+
+    assert!(
+        scenario
+            .components
+            .iter()
+            .flatten()
+            .any(|component| component.moniker.local_name() == Some("child")),
+        "repeated `each` slot use should root the child program from an external slot"
+    );
+    assert_eq!(scenario.bindings.len(), 1, "external binding should remain");
+}
+
+#[test]
+fn dce_keeps_externally_rooted_program_when_slot_is_only_used_in_repeated_env_each_without_exports()
+{
+    let child_program = serde_json::from_value(json!({
+        "image": "child",
+        "entrypoint": ["child"],
+        "env": {
+            "API_URLS": {
+                "each": "slots.api",
+                "value": "${item.url}",
+                "join": ","
+            }
+        },
+    }))
+    .expect("program");
+
+    let scenario =
+        externally_rooted_child_scenario("api", manifest_slot("http", true, true), child_program);
+    let scenario = assert_dce_idempotent(scenario);
+
+    assert!(
+        scenario
+            .components
+            .iter()
+            .flatten()
+            .any(|component| component.moniker.local_name() == Some("child")),
+        "repeated env `each` slot use should root the child program from an external slot"
+    );
+    assert_eq!(scenario.bindings.len(), 1, "external binding should remain");
+}
+
+#[test]
+fn dce_keeps_all_slot_dependencies_for_externally_rooted_program_without_exports() {
+    let slot_http = manifest_slot("http", true, false);
+    let provide_http: amber_manifest::ProvideDecl =
+        serde_json::from_value(json!({ "kind": "http", "endpoint": "admin" }))
+            .expect("provide decl");
+    let consumer_program = serde_json::from_value(json!({
+        "image": "consumer",
+        "entrypoint": ["consumer"],
+        "env": { "ALL_SLOTS": "${slots}" },
+    }))
+    .expect("program");
+    let provider_program = serde_json::from_value(json!({
+        "image": "provider",
+        "entrypoint": ["provider"],
+        "network": { "endpoints": [{ "name": "admin", "port": 9000 }] },
+    }))
+    .expect("program");
+
+    let mut root = component(0, "/");
+    root.slots.insert("api".to_string(), slot_http.clone());
+    root.children.extend([ComponentId(1), ComponentId(2)]);
+
+    let mut consumer = component(1, "/consumer");
+    consumer.parent = Some(ComponentId(0));
+    consumer.program = Some(consumer_program);
+    consumer.slots.insert("api".to_string(), slot_http.clone());
+    consumer
+        .slots
+        .insert("admin".to_string(), slot_http.clone());
+
+    let mut provider = component(2, "/provider");
+    provider.parent = Some(ComponentId(0));
+    provider.program = Some(provider_program);
+    provider.provides.insert("admin".to_string(), provide_http);
+
+    let scenario = Scenario {
+        root: ComponentId(0),
+        components: vec![Some(root), Some(consumer), Some(provider)],
+        bindings: vec![
+            external_binding(0, "api", 1, "api", true),
+            component_binding(2, "admin", 1, "admin"),
+        ],
+        exports: Vec::new(),
+    };
+
+    let scenario = assert_dce_idempotent(scenario);
+
+    assert!(
+        scenario
+            .components
+            .iter()
+            .flatten()
+            .any(|component| component.moniker.local_name() == Some("consumer")),
+        "consumer should remain live when any external binding roots an all-slots program"
+    );
+    assert!(
+        scenario
+            .components
+            .iter()
+            .flatten()
+            .any(|component| component.moniker.local_name() == Some("provider")),
+        "all-slots use should retain internal dependencies of the rooted program"
+    );
+    assert!(scenario.bindings.iter().any(|edge| {
+        matches!(
+            &edge.from,
+            BindingFrom::Component(from)
+                if from.component == ComponentId(2) && from.name == "admin"
+        ) && edge.to.component == ComponentId(1)
+            && edge.to.name == "admin"
+    }));
+}
+
+#[test]
+fn dce_prunes_dead_incoming_edges_of_live_externally_rooted_program() {
+    let slot_http = manifest_slot("http", true, false);
+    let provide_http: amber_manifest::ProvideDecl =
+        serde_json::from_value(json!({ "kind": "http", "endpoint": "admin" }))
+            .expect("provide decl");
+    let consumer_program = serde_json::from_value(json!({
+        "image": "consumer",
+        "entrypoint": ["consumer"],
+        "env": { "API_URL": "${slots.api.url}" },
+    }))
+    .expect("program");
+    let provider_program = serde_json::from_value(json!({
+        "image": "provider",
+        "entrypoint": ["provider"],
+        "network": { "endpoints": [{ "name": "admin", "port": 9000 }] },
+    }))
+    .expect("program");
+
+    let mut root = component(0, "/");
+    root.slots.insert("api".to_string(), slot_http.clone());
+    root.slots.insert("shadow".to_string(), slot_http.clone());
+    root.children.extend([ComponentId(1), ComponentId(2)]);
+
+    let mut consumer = component(1, "/consumer");
+    consumer.parent = Some(ComponentId(0));
+    consumer.program = Some(consumer_program);
+    consumer.slots.insert("api".to_string(), slot_http.clone());
+    consumer
+        .slots
+        .insert("admin".to_string(), slot_http.clone());
+    consumer
+        .slots
+        .insert("shadow".to_string(), slot_http.clone());
+
+    let mut provider = component(2, "/provider");
+    provider.parent = Some(ComponentId(0));
+    provider.program = Some(provider_program);
+    provider.provides.insert("admin".to_string(), provide_http);
+
+    let mut scenario = Scenario {
+        root: ComponentId(0),
+        components: vec![Some(root), Some(consumer), Some(provider)],
+        bindings: vec![
+            external_binding(0, "api", 1, "api", true),
+            component_binding(2, "admin", 1, "admin"),
+            external_binding(0, "shadow", 1, "shadow", true),
+        ],
+        exports: Vec::new(),
+    };
+    scenario.normalize_order();
+
+    let scenario = assert_dce_idempotent(scenario);
+    let root_after = scenario.component(ComponentId(0));
+
+    assert!(
+        scenario
+            .components
+            .iter()
+            .flatten()
+            .any(|component| component.moniker.local_name() == Some("consumer")),
+        "the consumer should remain live when it is externally rooted through api"
+    );
+    assert!(
+        !scenario
+            .components
+            .iter()
+            .flatten()
+            .any(|component| component.moniker.local_name() == Some("provider")),
+        "unused internal dependencies should still be pruned from a live consumer"
+    );
+    assert!(
+        !root_after.slots.contains_key("shadow"),
+        "unused external root slots should not survive just because the program is live"
+    );
+    assert_eq!(
+        scenario.bindings.len(),
+        1,
+        "only the binding for the actually used external slot should remain"
+    );
+    assert!(scenario.bindings.iter().all(|edge| {
+        matches!(
+            &edge.from,
+            BindingFrom::External(slot)
+                if slot.component == ComponentId(0) && slot.name == "api"
+        ) && edge.to.component == ComponentId(1)
+            && edge.to.name == "api"
+    }));
 }

--- a/compiler/src/tests.rs
+++ b/compiler/src/tests.rs
@@ -2283,6 +2283,559 @@ async fn compile_emits_manifest_lints() {
 }
 
 #[tokio::test]
+async fn optimized_compile_keeps_externally_rooted_child_without_exports() {
+    let dir = tmp_dir("external-rooted-child-dce");
+    let root_path = dir.path().join("root.json5");
+    let child_path = dir.path().join("child.json5");
+
+    write_file(
+        &child_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          program: {
+            image: "child",
+            entrypoint: ["child"],
+            env: { API_URL: "${slots.api.url}" }
+          },
+          slots: { api: { kind: "http" } }
+        }
+        "#,
+    );
+    write_file(
+        &root_path,
+        &format!(
+            r##"
+            {{
+              manifest_version: "0.1.0",
+              slots: {{ api: {{ kind: "http" }} }},
+              components: {{ child: "{child}" }},
+              bindings: [
+                {{ to: "#child.api", from: "self.api", weak: true }}
+              ]
+            }}
+            "##,
+            child = file_url(&child_path),
+        ),
+    );
+
+    let compiler = default_compiler();
+    let root_ref = manifest_ref_for_path(&root_path);
+    let output = compiler
+        .compile(root_ref, optimized_compile_options())
+        .await
+        .unwrap();
+
+    assert!(
+        output
+            .scenario
+            .components_iter()
+            .any(|(_, component)| component.moniker.as_str() == "/child"),
+        "optimized compile should retain the externally rooted child"
+    );
+    let root = output.scenario.component(output.scenario.root);
+    assert!(
+        root.slots.contains_key("api"),
+        "optimized compile should retain the external root slot"
+    );
+    assert!(output.scenario.bindings.iter().any(|binding| {
+        matches!(
+            &binding.from,
+            BindingFrom::External(slot)
+                if slot.component == output.scenario.root && slot.name == "api"
+        ) && binding.to.name == "api"
+    }));
+}
+
+#[tokio::test]
+async fn optimized_compile_keeps_root_program_driven_by_external_slot_without_exports() {
+    let dir = tmp_dir("external-rooted-root-dce");
+    let root_path = dir.path().join("root.json5");
+
+    write_file(
+        &root_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          slots: { api: { kind: "http" } },
+          program: {
+            image: "root",
+            entrypoint: ["root"],
+            env: { API_URL: "${slots.api.url}" }
+          }
+        }
+        "#,
+    );
+
+    let compiler = default_compiler();
+    let root_ref = manifest_ref_for_path(&root_path);
+    let output = compiler
+        .compile(root_ref, optimized_compile_options())
+        .await
+        .unwrap();
+
+    let root = output.scenario.component(output.scenario.root);
+    assert!(
+        root.program.is_some(),
+        "optimized compile should retain the root program when it consumes an external slot"
+    );
+    assert!(
+        root.slots.contains_key("api"),
+        "optimized compile should retain the root external slot"
+    );
+    assert!(output.scenario.bindings.iter().any(|binding| {
+        matches!(
+            &binding.from,
+            BindingFrom::External(slot)
+                if slot.component == output.scenario.root && slot.name == "api"
+        ) && binding.to.component == output.scenario.root
+            && binding.to.name == "api"
+    }));
+}
+
+#[tokio::test]
+async fn optimized_compile_keeps_externally_rooted_child_with_repeated_each_without_exports() {
+    let dir = tmp_dir("external-rooted-repeated-each-dce");
+    let root_path = dir.path().join("root.json5");
+    let child_path = dir.path().join("child.json5");
+
+    write_file(
+        &child_path,
+        r#"
+        {
+          manifest_version: "0.3.0",
+          program: {
+            image: "child",
+            entrypoint: [
+              "child",
+              { each: "slots.api", argv: ["--api", "${item.url}"] }
+            ]
+          },
+          slots: { api: { kind: "http", optional: true, multiple: true } }
+        }
+        "#,
+    );
+    write_file(
+        &root_path,
+        &format!(
+            r##"
+            {{
+              manifest_version: "0.3.0",
+              slots: {{ api: {{ kind: "http", optional: true, multiple: true }} }},
+              components: {{ child: "{child}" }},
+              bindings: [
+                {{ to: "#child.api", from: "self.api", weak: true }}
+              ]
+            }}
+            "##,
+            child = file_url(&child_path),
+        ),
+    );
+
+    let compiler = default_compiler();
+    let root_ref = manifest_ref_for_path(&root_path);
+    let output = compiler
+        .compile(root_ref, optimized_compile_options())
+        .await
+        .unwrap();
+
+    assert!(
+        output
+            .scenario
+            .components_iter()
+            .any(|(_, component)| component.moniker.as_str() == "/child"),
+        "optimized compile should retain the externally rooted child when it uses repeated `each`"
+    );
+    let root = output.scenario.component(output.scenario.root);
+    assert!(
+        root.slots.contains_key("api"),
+        "optimized compile should retain the external root slot for repeated `each`"
+    );
+    assert!(output.scenario.bindings.iter().any(|binding| {
+        matches!(
+            &binding.from,
+            BindingFrom::External(slot)
+                if slot.component == output.scenario.root && slot.name == "api"
+        ) && binding.to.name == "api"
+    }));
+}
+
+#[tokio::test]
+async fn optimized_compile_keeps_root_program_that_references_all_slots_without_exports() {
+    let dir = tmp_dir("external-rooted-all-slots-dce");
+    let root_path = dir.path().join("root.json5");
+
+    write_file(
+        &root_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          slots: {
+            admin: { kind: "http" },
+            api: { kind: "http" }
+          },
+          program: {
+            image: "root",
+            entrypoint: ["root"],
+            env: { ALL_SLOTS: "${slots}" }
+          }
+        }
+        "#,
+    );
+
+    let compiler = default_compiler();
+    let root_ref = manifest_ref_for_path(&root_path);
+    let output = compiler
+        .compile(root_ref, optimized_compile_options())
+        .await
+        .unwrap();
+
+    let root = output.scenario.component(output.scenario.root);
+    assert!(
+        root.program.is_some(),
+        "optimized compile should retain a root program that references all slots"
+    );
+    assert!(
+        root.slots.contains_key("admin") && root.slots.contains_key("api"),
+        "optimized compile should retain every root slot referenced by `${{slots}}`"
+    );
+    assert!(output.scenario.bindings.iter().any(|binding| {
+        matches!(
+            &binding.from,
+            BindingFrom::External(slot)
+                if slot.component == output.scenario.root && slot.name == "admin"
+        ) && binding.to.component == output.scenario.root
+            && binding.to.name == "admin"
+    }));
+    assert!(output.scenario.bindings.iter().any(|binding| {
+        matches!(
+            &binding.from,
+            BindingFrom::External(slot)
+                if slot.component == output.scenario.root && slot.name == "api"
+        ) && binding.to.component == output.scenario.root
+            && binding.to.name == "api"
+    }));
+}
+
+#[tokio::test]
+async fn check_suppresses_unused_program_for_externally_rooted_child() {
+    let dir = tmp_dir("external-rooted-child-lint");
+    let root_path = dir.path().join("root.json5");
+    let child_path = dir.path().join("child.json5");
+
+    write_file(
+        &child_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          program: {
+            image: "child",
+            entrypoint: ["child"],
+            env: { API_URL: "${slots.api.url}" }
+          },
+          slots: { api: { kind: "http" } }
+        }
+        "#,
+    );
+    write_file(
+        &root_path,
+        &format!(
+            r##"
+            {{
+              manifest_version: "0.1.0",
+              slots: {{ api: {{ kind: "http" }} }},
+              components: {{ child: "{child}" }},
+              bindings: [
+                {{ to: "#child.api", from: "self.api", weak: true }}
+              ]
+            }}
+            "##,
+            child = file_url(&child_path),
+        ),
+    );
+
+    let compiler = default_compiler();
+    let root_ref = manifest_ref_for_path(&root_path);
+    let output = compiler
+        .check(root_ref, standard_compile_options())
+        .await
+        .unwrap();
+
+    assert!(!output.has_errors);
+    assert!(
+        !has_diagnostic_code(&output.diagnostics, "manifest::unused_program"),
+        "unexpected manifest::unused_program diagnostics: {:?}",
+        output
+            .diagnostics
+            .iter()
+            .map(|diag| diag.to_string())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn check_suppresses_unused_program_for_root_program_driven_by_external_slot() {
+    let dir = tmp_dir("external-rooted-root-lint");
+    let root_path = dir.path().join("root.json5");
+
+    write_file(
+        &root_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          slots: { api: { kind: "http" } },
+          program: {
+            image: "root",
+            entrypoint: ["root"],
+            env: { API_URL: "${slots.api.url}" }
+          }
+        }
+        "#,
+    );
+
+    let compiler = default_compiler();
+    let root_ref = manifest_ref_for_path(&root_path);
+    let output = compiler
+        .check(root_ref, standard_compile_options())
+        .await
+        .unwrap();
+
+    assert!(!output.has_errors);
+    assert!(
+        !has_diagnostic_code(&output.diagnostics, "manifest::unused_program"),
+        "unexpected manifest::unused_program diagnostics: {:?}",
+        output
+            .diagnostics
+            .iter()
+            .map(|diag| diag.to_string())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn check_suppresses_unused_program_for_externally_rooted_child_with_repeated_each() {
+    let dir = tmp_dir("external-rooted-repeated-each-lint");
+    let root_path = dir.path().join("root.json5");
+    let child_path = dir.path().join("child.json5");
+
+    write_file(
+        &child_path,
+        r#"
+        {
+          manifest_version: "0.3.0",
+          program: {
+            image: "child",
+            entrypoint: [
+              "child",
+              { each: "slots.api", argv: ["--api", "${item.url}"] }
+            ]
+          },
+          slots: { api: { kind: "http", optional: true, multiple: true } }
+        }
+        "#,
+    );
+    write_file(
+        &root_path,
+        &format!(
+            r##"
+            {{
+              manifest_version: "0.3.0",
+              slots: {{ api: {{ kind: "http", optional: true, multiple: true }} }},
+              components: {{ child: "{child}" }},
+              bindings: [
+                {{ to: "#child.api", from: "self.api", weak: true }}
+              ]
+            }}
+            "##,
+            child = file_url(&child_path),
+        ),
+    );
+
+    let compiler = default_compiler();
+    let root_ref = manifest_ref_for_path(&root_path);
+    let output = compiler
+        .check(root_ref, standard_compile_options())
+        .await
+        .unwrap();
+
+    assert!(!output.has_errors);
+    assert!(
+        !has_diagnostic_code(&output.diagnostics, "manifest::unused_program"),
+        "unexpected manifest::unused_program diagnostics: {:?}",
+        output
+            .diagnostics
+            .iter()
+            .map(|diag| diag.to_string())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn check_keeps_unused_program_for_external_binding_to_unused_slot() {
+    let dir = tmp_dir("external-binding-unused-program-lint");
+    let root_path = dir.path().join("root.json5");
+    let child_path = dir.path().join("child.json5");
+
+    write_file(
+        &child_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          program: {
+            image: "child",
+            entrypoint: ["child"]
+          },
+          slots: { api: { kind: "http" } }
+        }
+        "#,
+    );
+    write_file(
+        &root_path,
+        &format!(
+            r##"
+            {{
+              manifest_version: "0.1.0",
+              slots: {{ api: {{ kind: "http" }} }},
+              components: {{ child: "{child}" }},
+              bindings: [
+                {{ to: "#child.api", from: "self.api", weak: true }}
+              ]
+            }}
+            "##,
+            child = file_url(&child_path),
+        ),
+    );
+
+    let compiler = default_compiler();
+    let root_ref = manifest_ref_for_path(&root_path);
+    let output = compiler
+        .check(root_ref, standard_compile_options())
+        .await
+        .unwrap();
+
+    assert!(!output.has_errors);
+    assert!(
+        has_diagnostic_code(&output.diagnostics, "manifest::unused_program"),
+        "expected manifest::unused_program diagnostics, got {:?}",
+        output
+            .diagnostics
+            .iter()
+            .map(|diag| diag.to_string())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn check_suppresses_unused_program_but_not_unused_provide_for_externally_rooted_child() {
+    let dir = tmp_dir("external-rooted-narrow-lint");
+    let root_path = dir.path().join("root.json5");
+    let child_path = dir.path().join("child.json5");
+
+    write_file(
+        &child_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          program: {
+            image: "child",
+            entrypoint: ["child"],
+            env: { API_URL: "${slots.api.url}" },
+            network: { endpoints: [{ name: "out", port: 8080 }] }
+          },
+          slots: { api: { kind: "http" } },
+          provides: {
+            out: { kind: "http", endpoint: "out" }
+          }
+        }
+        "#,
+    );
+    write_file(
+        &root_path,
+        &format!(
+            r##"
+            {{
+              manifest_version: "0.1.0",
+              slots: {{ api: {{ kind: "http" }} }},
+              components: {{ child: "{child}" }},
+              bindings: [
+                {{ to: "#child.api", from: "self.api", weak: true }}
+              ]
+            }}
+            "##,
+            child = file_url(&child_path),
+        ),
+    );
+
+    let compiler = default_compiler();
+    let root_ref = manifest_ref_for_path(&root_path);
+    let output = compiler
+        .check(root_ref, standard_compile_options())
+        .await
+        .unwrap();
+    let diagnostics: Vec<_> = output
+        .diagnostics
+        .iter()
+        .map(|diag| diag.to_string())
+        .collect();
+
+    assert!(!output.has_errors);
+    assert!(
+        !has_diagnostic_code(&output.diagnostics, "manifest::unused_program"),
+        "unexpected manifest::unused_program diagnostics: {:?}",
+        diagnostics
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diag| diag == "provide `out` is never used or exported (in component /child)"),
+        "expected the child unused-provide warning to remain: {:?}",
+        diagnostics
+    );
+}
+
+#[tokio::test]
+async fn check_suppresses_unused_program_for_root_program_that_references_all_slots() {
+    let dir = tmp_dir("external-rooted-all-slots-lint");
+    let root_path = dir.path().join("root.json5");
+
+    write_file(
+        &root_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          slots: {
+            admin: { kind: "http" },
+            api: { kind: "http" }
+          },
+          program: {
+            image: "root",
+            entrypoint: ["root"],
+            env: { ALL_SLOTS: "${slots}" }
+          }
+        }
+        "#,
+    );
+
+    let compiler = default_compiler();
+    let root_ref = manifest_ref_for_path(&root_path);
+    let output = compiler
+        .check(root_ref, standard_compile_options())
+        .await
+        .unwrap();
+
+    assert!(!output.has_errors);
+    assert!(
+        !has_diagnostic_code(&output.diagnostics, "manifest::unused_program"),
+        "unexpected manifest::unused_program diagnostics: {:?}",
+        output
+            .diagnostics
+            .iter()
+            .map(|diag| diag.to_string())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
 async fn check_treats_weak_binding_targets_as_optional_for_unused_slot_lint() {
     let dir = tmp_dir("scenario-optional-slot-downstream-lint");
     let root_path = dir.path().join("root.json5");


### PR DESCRIPTION
This is in acknowledgement that some scenarios may only import things, but they create side effects through imports. DCE acknowledges external slots as being able to cause side effects now by treating them as liveness roots.