### PR TITLE
add env var defaults

### DIFF
--- a/compiler/config/src/env.rs
+++ b/compiler/config/src/env.rs
@@ -154,14 +154,9 @@ pub fn build_root_config(
             continue;
         }
         let leaf_schema = schema_lookup_ref(root_schema, &leaf.path)?;
-        let default_value = if let Some(v) = leaf_schema.get("default") {
-            v.clone()
-        } else if leaf_schema.get("type").and_then(|t| t.as_str()) == Some("string") {
-            Value::String(String::new())
-        } else {
-            continue;
-        };
-        insert_path(&mut obj, &leaf.path, default_value)?;
+        if let Some(default_value) = leaf_schema.get("default") {
+            insert_path(&mut obj, &leaf.path, default_value.clone())?;
+        }
     }
 
     let out = Value::Object(obj);

--- a/compiler/config/src/lib.rs
+++ b/compiler/config/src/lib.rs
@@ -313,7 +313,7 @@ mod tests {
     }
 
     #[test]
-    fn missing_optional_without_default() {
+    fn missing_optional_without_default_is_omitted() {
         let schema = json!({
             "type": "object",
             "properties": {
@@ -331,7 +331,7 @@ mod tests {
 
         let config = build_root_config(&schema, &env).expect("config should parse");
         assert_eq!(get_by_path(&config, "required_key").unwrap(), "hello");
-        assert_eq!(get_by_path(&config, "optional_key").unwrap(), "");
+        assert!(get_by_path(&config, "optional_key").is_err());
     }
 
     #[test]


### PR DESCRIPTION
Adds support for default values in the env var config. I think all optional env vars need a default specified or else the quick-submit flow errors with `interpolation error: config.green_deepseek_api_key not found (missing key "green_deepseek_api_key")`

Claude summary of the issue:
```
Full config flow (quick-submit)

     1. Scenario builder (amber_scenario_builder.rs): Merges all manifest config_schema.properties with prefixes. Every property (required or not) gets a
     ${config.prefix_key} template ref in the component's config block.
     2. GitHub Actions runner (quick-submit-runner.yml): Decrypts user-provided secrets and writes them to AMBER_CONFIG_* env vars. Only secrets the user
     actually provided are written — optional keys with no user value are simply absent.
     3. Amber compiler (docker_compose/mod.rs:905-908): For required leaves, generates AMBER_CONFIG_FOO=${AMBER_CONFIG_FOO?error}. For optional leaves,
     generates bare AMBER_CONFIG_FOO (Docker Compose pass-through — unset if host env lacks it).
     4. Container runtime (runtime/helper/src/lib.rs): Collects AMBER_CONFIG_* from the container env into config_env map. Missing vars are simply absent
     from the map.
     5. build_root_config (env.rs:124): Iterates config_env only — never sees missing optional vars. The root config object lacks those keys.
     6. eval_config_template (template.rs): Tries to resolve ${config.green_deepseek_api_key} against the root config. Fails because the key doesn't
     exist.
```

Defaults can be specified like this:
```
config_schema: {
    type: "object",
    properties: {
      openai_api_key: { type: "string", secret: true, default: "" },
      gemini_api_key: { type: "string", secret: true, default: "" },
      deepseek_api_key: { type: "string", secret: true, default: "" },
    },
    required: [],
    additionalProperties: false,
```

This PR does not add full support for optional config vars since the default is required. Adding that full support requires more invasive changes to amber, which can be done in a future PR (with @nhynes go-ahead)