### PR TITLE
Add governance syntax

### DIFF
--- a/cli/tests/ui/lint_unused_use.args
+++ b/cli/tests/ui/lint_unused_use.args
@@ -1,0 +1,1 @@
+-D warnings

--- a/cli/tests/ui/lint_unused_use.json5
+++ b/cli/tests/ui/lint_unused_use.json5
@@ -1,6 +1,6 @@
 {
   manifest_version: "0.1.0",
-  experimental_features: ["policies"],
+  experimental_features: ["governance"],
   use: {
     wrapper: "./lint_unused_use_wrapper.json5",
   },

--- a/cli/tests/ui/lint_unused_use.json5
+++ b/cli/tests/ui/lint_unused_use.json5
@@ -1,0 +1,7 @@
+{
+  manifest_version: "0.1.0",
+  experimental_features: ["policies"],
+  use: {
+    wrapper: "./lint_unused_use_wrapper.json5",
+  },
+}

--- a/cli/tests/ui/lint_unused_use.stderr
+++ b/cli/tests/ui/lint_unused_use.stderr
@@ -1,0 +1,13 @@
+manifest::unused_use
+
+  x use `#wrapper` is never referenced (in component /)
+   ,-[<CARGO_MANIFEST_DIR>/tests/ui/lint_unused_use.json5:5:5]
+ 4 |   use: {
+ 5 |     wrapper: "./lint_unused_use_wrapper.json5",
+   :     ^^^|^^^
+   :        `-- unused `use` entry `#wrapper`
+ 6 |   },
+   `----
+  help: warning treated as error because it was denied via `-D warnings`
+        Remove the `use` entry `#wrapper` if it is not needed, or reference it from `policies`.
+Error:   × check failed

--- a/cli/tests/ui/lint_unused_use_wrapper.json5
+++ b/cli/tests/ui/lint_unused_use_wrapper.json5
@@ -1,0 +1,3 @@
+{
+  manifest_version: "0.1.0",
+}

--- a/cli/tests/ui/manifest_unknown_experimental_feature.stderr
+++ b/cli/tests/ui/manifest_unknown_experimental_feature.stderr
@@ -2,11 +2,11 @@ Error: manifest::validation_error
 
   × check failed
   ╰─▶ manifest validation error at experimental_features[0]: unknown variant
-      `not_a_real_feature`, expected `docker` or `kvm`
+      `not_a_real_feature`, expected one of `docker`, `kvm`, `policies`
    ╭─[<CARGO_MANIFEST_DIR>/tests/ui/manifest_unknown_experimental_feature.json5:3:27]
  2 │   manifest_version: "0.1.0",
  3 │   experimental_features: ["not_a_real_feature"],
    ·                           ──────────┬─────────
-   ·                                     ╰── unknown variant `not_a_real_feature`, expected `docker` or `kvm`
+   ·                                     ╰── unknown variant `not_a_real_feature`, expected one of `docker`, `kvm`, `policies`
  4 │ }
    ╰────

--- a/cli/tests/ui/manifest_unknown_experimental_feature.stderr
+++ b/cli/tests/ui/manifest_unknown_experimental_feature.stderr
@@ -2,11 +2,11 @@ Error: manifest::validation_error
 
   × check failed
   ╰─▶ manifest validation error at experimental_features[0]: unknown variant
-      `not_a_real_feature`, expected one of `docker`, `kvm`, `policies`
+      `not_a_real_feature`, expected one of `docker`, `kvm`, `governance`
    ╭─[<CARGO_MANIFEST_DIR>/tests/ui/manifest_unknown_experimental_feature.json5:3:27]
  2 │   manifest_version: "0.1.0",
  3 │   experimental_features: ["not_a_real_feature"],
    ·                           ──────────┬─────────
-   ·                                     ╰── unknown variant `not_a_real_feature`, expected one of `docker`, `kvm`, `policies`
+   ·                                     ╰── unknown variant `not_a_real_feature`, expected one of `docker`, `kvm`, `governance`
  4 │ }
    ╰────

--- a/cli/tests/ui/policies_requires_feature.json5
+++ b/cli/tests/ui/policies_requires_feature.json5
@@ -1,0 +1,4 @@
+{
+  manifest_version: "0.1.0",
+  policies: ["#wrapper.rewrite"],
+}

--- a/cli/tests/ui/policies_requires_feature.stderr
+++ b/cli/tests/ui/policies_requires_feature.stderr
@@ -1,7 +1,7 @@
 Error: manifest::section_requires_feature
 
   × check failed
-  ╰─▶ `policies` requires experimental feature `policies`
+  ╰─▶ `policies` requires experimental feature `governance`
    ╭─[<CARGO_MANIFEST_DIR>/tests/ui/policies_requires_feature.json5:3:14]
  2 │   manifest_version: "0.1.0",
  3 │   policies: ["#wrapper.rewrite"],

--- a/cli/tests/ui/policies_requires_feature.stderr
+++ b/cli/tests/ui/policies_requires_feature.stderr
@@ -1,0 +1,13 @@
+Error: manifest::section_requires_feature
+
+  × check failed
+  ╰─▶ `policies` requires experimental feature `policies`
+   ╭─[<CARGO_MANIFEST_DIR>/tests/ui/policies_requires_feature.json5:3:14]
+ 2 │   manifest_version: "0.1.0",
+ 3 │   policies: ["#wrapper.rewrite"],
+   ·              ─────────┬────────
+   ·                       ╰── `policies` used here
+ 4 │ }
+   ╰────
+  help: Add this feature to `experimental_features` in the same manifest, or
+        stop using this section.

--- a/cli/tests/ui/policy_export_unresolved.json5
+++ b/cli/tests/ui/policy_export_unresolved.json5
@@ -1,6 +1,6 @@
 {
   manifest_version: "0.1.0",
-  experimental_features: ["policies"],
+  experimental_features: ["governance"],
   use: {
     wrapper: "./policy_export_unresolved_wrapper.json5",
   },

--- a/cli/tests/ui/policy_export_unresolved.json5
+++ b/cli/tests/ui/policy_export_unresolved.json5
@@ -1,0 +1,8 @@
+{
+  manifest_version: "0.1.0",
+  experimental_features: ["policies"],
+  use: {
+    wrapper: "./policy_export_unresolved_wrapper.json5",
+  },
+  policies: ["#wrapper.rewrite"],
+}

--- a/cli/tests/ui/policy_export_unresolved.stderr
+++ b/cli/tests/ui/policy_export_unresolved.stderr
@@ -1,0 +1,14 @@
+Error: compiler::policy_export_unresolved
+
+  × check failed
+  ╰─▶ policy `#wrapper.rewrite` could not resolve export `rewrite` from use
+      `#wrapper`
+   ╭─[<CARGO_MANIFEST_DIR>/tests/ui/policy_export_unresolved.json5:7:14]
+ 6 │   },
+ 7 │   policies: ["#wrapper.rewrite"],
+   ·              ─────────┬────────
+   ·                       ╰── policy referenced here
+ 8 │ }
+   ╰────
+  help: Ensure the used manifest exports this capability and that any child
+        export chain resolves to a real export.

--- a/cli/tests/ui/policy_export_unresolved_wrapper.json5
+++ b/cli/tests/ui/policy_export_unresolved_wrapper.json5
@@ -1,0 +1,3 @@
+{
+  manifest_version: "0.1.0",
+}

--- a/cli/tests/ui/policy_invalid_export.json5
+++ b/cli/tests/ui/policy_invalid_export.json5
@@ -1,0 +1,8 @@
+{
+  manifest_version: "0.1.0",
+  experimental_features: ["policies"],
+  use: {
+    wrapper: "./policy_invalid_export_wrapper.json5",
+  },
+  policies: ["#wrapper.rewrite"],
+}

--- a/cli/tests/ui/policy_invalid_export.json5
+++ b/cli/tests/ui/policy_invalid_export.json5
@@ -1,6 +1,6 @@
 {
   manifest_version: "0.1.0",
-  experimental_features: ["policies"],
+  experimental_features: ["governance"],
   use: {
     wrapper: "./policy_invalid_export_wrapper.json5",
   },

--- a/cli/tests/ui/policy_invalid_export.stderr
+++ b/cli/tests/ui/policy_invalid_export.stderr
@@ -1,0 +1,23 @@
+Error: compiler::invalid_policy_export
+
+  × check failed
+  ╰─▶ policy `#wrapper.rewrite` must resolve to a provide, not a slot
+   ╭─[<CARGO_MANIFEST_DIR>/tests/ui/policy_invalid_export.json5:7:14]
+ 6 │   },
+ 7 │   policies: ["#wrapper.rewrite"],
+   ·              ─────────┬────────
+   ·                       ╰── policy referenced here
+ 8 │ }
+   ╰────
+  help: Policy refs must resolve to an exported `http` provide with profile
+        `policy`.
+
+Advice: 
+  ☞ policy `#wrapper.rewrite` resolves here
+   ╭─[<CARGO_MANIFEST_DIR>/tests/ui/policy_invalid_export_wrapper.json5:4:5]
+ 3 │   slots: {
+ 4 │     rewrite: { kind: "http", profile: "policy", optional: true },
+   ·     ───┬───
+   ·        ╰── resolved slot declared here
+ 5 │   },
+   ╰────

--- a/cli/tests/ui/policy_invalid_export_wrapper.json5
+++ b/cli/tests/ui/policy_invalid_export_wrapper.json5
@@ -1,0 +1,9 @@
+{
+  manifest_version: "0.1.0",
+  slots: {
+    rewrite: { kind: "http", profile: "policy", optional: true },
+  },
+  exports: {
+    rewrite: "rewrite",
+  },
+}

--- a/cli/tests/ui/policy_ref_invalid.json5
+++ b/cli/tests/ui/policy_ref_invalid.json5
@@ -1,0 +1,8 @@
+{
+  manifest_version: "0.1.0",
+  experimental_features: ["policies"],
+  use: {
+    wrapper: "https://example.com/wrapper.json5",
+  },
+  policies: ["wrapper.rewrite"],
+}

--- a/cli/tests/ui/policy_ref_invalid.json5
+++ b/cli/tests/ui/policy_ref_invalid.json5
@@ -1,6 +1,6 @@
 {
   manifest_version: "0.1.0",
-  experimental_features: ["policies"],
+  experimental_features: ["governance"],
   use: {
     wrapper: "https://example.com/wrapper.json5",
   },

--- a/cli/tests/ui/policy_ref_invalid.stderr
+++ b/cli/tests/ui/policy_ref_invalid.stderr
@@ -1,0 +1,12 @@
+Error: manifest::validation_error
+
+  × check failed
+  ╰─▶ manifest validation error at policies[0]: invalid policy ref
+      `wrapper.rewrite`: expected `#<use>.<export>`
+   ╭─[<CARGO_MANIFEST_DIR>/tests/ui/policy_ref_invalid.json5:7:14]
+ 6 │   },
+ 7 │   policies: ["wrapper.rewrite"],
+   ·              ────────┬────────
+   ·                      ╰── invalid policy ref `wrapper.rewrite`: expected `#<use>.<export>`
+ 8 │ }
+   ╰────

--- a/cli/tests/ui/typo_components_key.stderr
+++ b/cli/tests/ui/typo_components_key.stderr
@@ -3,12 +3,13 @@ Error: manifest::validation_error
   × check failed
   ╰─▶ manifest validation error at componentz: unknown field `componentz`,
       expected one of `manifest_version`, `experimental_features`, `program`,
-      `components`, `environments`, `config_schema`, `slots`, `provides`,
-      `resources`, `child_templates`, `bindings`, `exports`, `metadata`
+      `components`, `use`, `environments`, `config_schema`, `slots`,
+      `provides`, `resources`, `child_templates`, `bindings`, `policies`,
+      `exports`, `metadata`
    ╭─[<CARGO_MANIFEST_DIR>/tests/ui/typo_components_key.json5:3:3]
  2 │   manifest_version: "0.1.0",
  3 │   componentz: {
    ·   ─────┬────
-   ·        ╰── unknown field `componentz`, expected one of `manifest_version`, `experimental_features`, `program`, `components`, `environments`, `config_schema`, `slots`, `provides`, `resources`, `child_templates`, `bindings`, `exports`, `metadata`
+   ·        ╰── unknown field `componentz`, expected one of `manifest_version`, `experimental_features`, `program`, `components`, `use`, `environments`, `config_schema`, `slots`, `provides`, `resources`, `child_templates`, `bindings`, `policies`, `exports`, `metadata`
  4 │     tau2: "./tau2.json5",
    ╰────

--- a/cli/tests/ui/use_requires_root_slot.json5
+++ b/cli/tests/ui/use_requires_root_slot.json5
@@ -1,0 +1,8 @@
+{
+  manifest_version: "0.1.0",
+  experimental_features: ["policies"],
+  use: {
+    wrapper: "./use_requires_root_slot_wrapper.json5",
+  },
+  policies: ["#wrapper.rewrite"],
+}

--- a/cli/tests/ui/use_requires_root_slot.json5
+++ b/cli/tests/ui/use_requires_root_slot.json5
@@ -1,6 +1,6 @@
 {
   manifest_version: "0.1.0",
-  experimental_features: ["policies"],
+  experimental_features: ["governance"],
   use: {
     wrapper: "./use_requires_root_slot_wrapper.json5",
   },

--- a/cli/tests/ui/use_requires_root_slot.stderr
+++ b/cli/tests/ui/use_requires_root_slot.stderr
@@ -1,0 +1,24 @@
+Error: compiler::use_requires_root_slots
+
+  × check failed
+  ╰─▶ use `#wrapper` requires root slot(s) that the main scenario cannot bind:
+      upstream
+   ╭─[<CARGO_MANIFEST_DIR>/tests/ui/use_requires_root_slot.json5:5:14]
+ 4 │   use: {
+ 5 │     wrapper: "./use_requires_root_slot_wrapper.json5",
+   ·              ────────────────────┬───────────────────
+   ·                                  ╰── use declared here
+ 6 │   },
+   ╰────
+  help: Make these slots optional or move the required inputs inside the used
+        manifest.
+
+Advice: 
+  ☞ use `#wrapper` requires slot `upstream` here
+   ╭─[<CARGO_MANIFEST_DIR>/tests/ui/use_requires_root_slot_wrapper.json5:4:5]
+ 3 │   slots: {
+ 4 │     upstream: { kind: "http" },
+   ·     ────┬───
+   ·         ╰── required slot declared here
+ 5 │   },
+   ╰────

--- a/cli/tests/ui/use_requires_root_slot_wrapper.json5
+++ b/cli/tests/ui/use_requires_root_slot_wrapper.json5
@@ -1,0 +1,17 @@
+{
+  manifest_version: "0.1.0",
+  slots: {
+    upstream: { kind: "http" },
+  },
+  program: {
+    image: "wrapper",
+    entrypoint: ["wrapper"],
+    network: { endpoints: [{ name: "api", port: 80 }] },
+  },
+  provides: {
+    rewrite: { kind: "http", profile: "policy", endpoint: "api" },
+  },
+  exports: {
+    rewrite: "rewrite",
+  },
+}

--- a/cli/tests/ui/use_unknown_environment.json5
+++ b/cli/tests/ui/use_unknown_environment.json5
@@ -1,0 +1,13 @@
+{
+  manifest_version: "0.1.0",
+  experimental_features: ["policies"],
+  use: {
+    wrapper: {
+      manifest: "https://example.com/wrapper.json5",
+      environment: "missing",
+    },
+  },
+  environments: {
+    present: { resolvers: ["x"] },
+  },
+}

--- a/cli/tests/ui/use_unknown_environment.json5
+++ b/cli/tests/ui/use_unknown_environment.json5
@@ -1,6 +1,6 @@
 {
   manifest_version: "0.1.0",
-  experimental_features: ["policies"],
+  experimental_features: ["governance"],
   use: {
     wrapper: {
       manifest: "https://example.com/wrapper.json5",

--- a/cli/tests/ui/use_unknown_environment.stderr
+++ b/cli/tests/ui/use_unknown_environment.stderr
@@ -1,0 +1,11 @@
+Error: manifest::unknown_use_environment
+
+  × check failed
+  ╰─▶ use `#wrapper` references unknown environment `missing`
+   ╭─[<CARGO_MANIFEST_DIR>/tests/ui/use_unknown_environment.json5:7:20]
+ 6 │       manifest: "https://example.com/wrapper.json5",
+ 7 │       environment: "missing",
+   ·                    ────┬────
+   ·                        ╰── unknown environment referenced here
+ 8 │     },
+   ╰────

--- a/compiler/manifest/README.md
+++ b/compiler/manifest/README.md
@@ -115,11 +115,13 @@ Top-level object:
 
   program: { /* ... */ },      // optional
   components: { /* ... */ },   // optional; default {}
+  use: { /* ... */ },          // optional; default {}
   config_schema: { /* ... */ },// optional
   slots: { /* ... */ },        // optional; default {}
   resources: { /* ... */ },    // optional; default {}
   provides: { /* ... */ },      // optional; default {}
   bindings: [ /* ... */ ],      // optional; default []
+  policies: [ /* ... */ ],      // optional; default []
   exports: { /* ... */ },       // optional; default {}
   metadata: { /* ... */ },      // optional
 }
@@ -132,6 +134,8 @@ Top-level object:
 Current values:
 
 * `"docker"`
+* `"kvm"`
+* `"policies"` - required for the `use` and `policies` top-level sections
 
 Rules:
 

--- a/compiler/manifest/README.md
+++ b/compiler/manifest/README.md
@@ -135,7 +135,7 @@ Current values:
 
 * `"docker"`
 * `"kvm"`
-* `"policies"` - required for the `use` and `policies` top-level sections
+* `"governance"` - required for the `use` and `policies` top-level sections
 
 Rules:
 

--- a/compiler/manifest/src/document.rs
+++ b/compiler/manifest/src/document.rs
@@ -169,9 +169,11 @@ fn labels_for_manifest_error(
                 Some("export target here".to_string()),
             )]
         }
+        ManifestError::InvalidPolicyRef { input, .. } => labels_for_policy_ref(spans, input),
         ManifestError::AmbiguousCapabilityName { name } => {
             labels_for_ambiguous_capability_name(spans, name)
         }
+        ManifestError::UnknownPolicyUse { alias } => labels_for_policy_use(spans, alias),
         ManifestError::DuplicateBindingTarget { to, slot } => {
             labels_for_duplicate_binding_target(spans, to, slot)
         }
@@ -190,6 +192,9 @@ fn labels_for_manifest_error(
         ManifestError::UnknownFrameworkCapability { capability, .. }
         | ManifestError::FrameworkCapabilityRequiresFeature { capability, .. } => {
             labels_for_framework_capability_use(spans, capability)
+        }
+        ManifestError::SectionRequiresFeature { section, .. } => {
+            labels_for_section_requires_feature(spans, section)
         }
         ManifestError::DuplicateEndpointName { name } => {
             labels_for_duplicate_endpoint_name(spans, name)
@@ -251,6 +256,9 @@ fn labels_for_manifest_error(
         ManifestError::EnvironmentCycle { name } => labels_for_environment_cycle(spans, name),
         ManifestError::UnknownComponentEnvironment { child, .. } => {
             labels_for_unknown_component_environment(spans, child)
+        }
+        ManifestError::UnknownUseEnvironment { name, .. } => {
+            labels_for_unknown_use_environment(spans, name)
         }
         _ => Vec::new(),
     }
@@ -383,6 +391,7 @@ fn labels_for_invalid_name(
     let span = match kind {
         "environment" => spans.environments.get(name).map(|s| s.name),
         "child" => spans.components.get(name).map(|s| s.name),
+        "use" => spans.uses.get(name).map(|s| s.name),
         "slot" => spans.slots.get(name).map(|s| s.name),
         "provide" => spans.provides.get(name).map(|s| s.capability.name),
         "export" => spans.exports.get(name).map(|s| s.name),
@@ -778,6 +787,59 @@ fn labels_for_unknown_component_environment(
     vec![primary(
         span_or_default(span),
         Some("unknown environment referenced here".to_string()),
+    )]
+}
+
+fn labels_for_unknown_use_environment(spans: &ManifestSpans, name: &str) -> Vec<LabeledSpan> {
+    let span = spans
+        .uses
+        .get(name)
+        .and_then(|component| component.environment.or(Some(component.name)));
+    vec![primary(
+        span_or_default(span),
+        Some("unknown environment referenced here".to_string()),
+    )]
+}
+
+fn labels_for_policy_ref(spans: &ManifestSpans, input: &str) -> Vec<LabeledSpan> {
+    let span = spans
+        .policies
+        .iter()
+        .find(|policy| policy.value.as_deref() == Some(input))
+        .map(|policy| policy.whole);
+    vec![primary(
+        span_or_default(span),
+        Some("policy ref here".to_string()),
+    )]
+}
+
+fn labels_for_policy_use(spans: &ManifestSpans, alias: &str) -> Vec<LabeledSpan> {
+    let prefix = format!("#{alias}.");
+    let span = spans
+        .policies
+        .iter()
+        .find(|policy| {
+            policy
+                .value
+                .as_deref()
+                .is_some_and(|value| value.starts_with(prefix.as_str()))
+        })
+        .map(|policy| policy.whole);
+    vec![primary(
+        span_or_default(span),
+        Some("unknown use referenced here".to_string()),
+    )]
+}
+
+fn labels_for_section_requires_feature(spans: &ManifestSpans, section: &str) -> Vec<LabeledSpan> {
+    let span = match section {
+        "use" => spans.use_section,
+        "policies" => spans.policies.first().map(|policy| policy.whole),
+        _ => None,
+    };
+    vec![primary(
+        span_or_default(span),
+        Some(format!("`{section}` used here")),
     )]
 }
 

--- a/compiler/manifest/src/error.rs
+++ b/compiler/manifest/src/error.rs
@@ -74,6 +74,10 @@ pub enum Error {
     #[diagnostic(code(manifest::invalid_export_target))]
     InvalidExportTarget { input: String, message: String },
 
+    #[error("invalid policy ref `{input}`: {message}")]
+    #[diagnostic(code(manifest::invalid_policy_ref))]
+    InvalidPolicyRef { input: String, message: String },
+
     #[error("invalid {kind} name `{name}`: dots are reserved")]
     #[diagnostic(code(manifest::invalid_name))]
     InvalidName { kind: &'static str, name: String },
@@ -184,6 +188,19 @@ pub enum Error {
         )
     )]
     FrameworkCapabilityRequiresFeature { capability: String, feature: String },
+
+    #[error("`{section}` requires experimental feature `{feature}`")]
+    #[diagnostic(
+        code(manifest::section_requires_feature),
+        help(
+            "Add this feature to `experimental_features` in the same manifest, or stop using this \
+             section."
+        )
+    )]
+    SectionRequiresFeature {
+        section: &'static str,
+        feature: String,
+    },
 
     #[error("duplicate endpoint name `{name}`")]
     #[diagnostic(code(manifest::duplicate_endpoint_name))]
@@ -297,6 +314,14 @@ pub enum Error {
     #[error("component `#{child}` references unknown environment `{environment}`")]
     #[diagnostic(code(manifest::unknown_component_environment))]
     UnknownComponentEnvironment { child: String, environment: String },
+
+    #[error("use `#{name}` references unknown environment `{environment}`")]
+    #[diagnostic(code(manifest::unknown_use_environment))]
+    UnknownUseEnvironment { name: String, environment: String },
+
+    #[error("policy references unknown use `#{alias}`")]
+    #[diagnostic(code(manifest::unknown_policy_use))]
+    UnknownPolicyUse { alias: String },
 }
 
 fn manifest_validation_path(diag: &DiagnosticError) -> &str {

--- a/compiler/manifest/src/lib.rs
+++ b/compiler/manifest/src/lib.rs
@@ -38,11 +38,11 @@ pub use schema::{
     CapabilityTransport, ChildTemplateDecl, ChildTemplateLimitsDecl, ChildTemplateManifestDecl,
     ComponentDecl, ComponentRef, ConfigSchema, Endpoint, EndpointPort, EnvironmentDecl,
     ExportTarget, LocalComponentRef, ManifestBinding, MountSource, Network, NetworkProtocol,
-    Program, ProgramCommandKind, ProgramCommon, ProgramConfigUseSite, ProgramImage, ProgramMount,
-    ProgramNetworkRef, ProgramPath, ProgramVmField, ProvideDecl, RawBinding, RawExportTarget,
-    RawProgram, RawProgramCommon, RawProgramImage, RawProgramPath, RawProgramVmField,
-    RawVmCloudInit, RawVmProgram, RealmSelector, ResourceDecl, RuntimeBackend, SlotDecl,
-    VmCloudInit, VmEgress, VmNetwork, VmProgram, VmScalarU32,
+    PolicyRef, Program, ProgramCommandKind, ProgramCommon, ProgramConfigUseSite, ProgramImage,
+    ProgramMount, ProgramNetworkRef, ProgramPath, ProgramVmField, ProvideDecl, RawBinding,
+    RawExportTarget, RawProgram, RawProgramCommon, RawProgramImage, RawProgramPath,
+    RawProgramVmField, RawVmCloudInit, RawVmProgram, RealmSelector, ResourceDecl, RuntimeBackend,
+    SlotDecl, VmCloudInit, VmEgress, VmNetwork, VmProgram, VmScalarU32,
 };
 pub use slot_query::{
     SlotQuery, SlotQueryError, SlotQueryValidation, SlotTarget, parse_slot_query,
@@ -50,6 +50,6 @@ pub use slot_query::{
 };
 pub use spans::{
     BindingSpans, BindingTargetKey, CapabilityDeclSpans, ComponentDeclSpans, EndpointSpans,
-    EnvironmentSpans, ExportSpans, ManifestSpans, ProgramSpans, ProvideDeclSpans,
+    EnvironmentSpans, ExportSpans, ManifestSpans, PolicyRefSpans, ProgramSpans, ProvideDeclSpans,
     ResourceDeclSpans, ResourceParamsSpans, span_for_json_pointer,
 };

--- a/compiler/manifest/src/lint.rs
+++ b/compiler/manifest/src/lint.rs
@@ -55,6 +55,24 @@ pub enum ManifestLint {
         span: SourceSpan,
     },
 
+    #[error("use `#{name}` is never referenced (in component {component})")]
+    #[diagnostic(
+        code(manifest::unused_use),
+        severity(Warning),
+        help(
+            "Remove the `use` entry `#{name}` if it is not needed, or reference it from \
+             `policies`."
+        )
+    )]
+    UnusedUse {
+        name: String,
+        component: String,
+        #[source_code]
+        src: NamedSource<Arc<str>>,
+        #[label("unused `use` entry `#{name}`")]
+        span: SourceSpan,
+    },
+
     #[error("config property `{path}` is never used (in component {component})")]
     #[diagnostic(
         code(manifest::unused_config),

--- a/compiler/manifest/src/manifest/mod.rs
+++ b/compiler/manifest/src/manifest/mod.rs
@@ -84,7 +84,7 @@ pub struct RawManifest {
 pub enum ExperimentalFeature {
     Docker,
     Kvm,
-    Policies,
+    Governance,
 }
 
 impl fmt::Display for ExperimentalFeature {
@@ -92,7 +92,7 @@ impl fmt::Display for ExperimentalFeature {
         match self {
             ExperimentalFeature::Docker => f.write_str("docker"),
             ExperimentalFeature::Kvm => f.write_str("kvm"),
-            ExperimentalFeature::Policies => f.write_str("policies"),
+            ExperimentalFeature::Governance => f.write_str("governance"),
         }
     }
 }
@@ -914,12 +914,16 @@ impl RawManifest {
         validate_program_syntax_manifest_version(&manifest_version, program.as_ref())?;
 
         if !r#use.is_empty() {
-            require_section_feature("use", ExperimentalFeature::Policies, &experimental_features)?;
+            require_section_feature(
+                "use",
+                ExperimentalFeature::Governance,
+                &experimental_features,
+            )?;
         }
         if !policies.is_empty() {
             require_section_feature(
                 "policies",
-                ExperimentalFeature::Policies,
+                ExperimentalFeature::Governance,
                 &experimental_features,
             )?;
         }

--- a/compiler/manifest/src/manifest/mod.rs
+++ b/compiler/manifest/src/manifest/mod.rs
@@ -24,8 +24,9 @@ use crate::{
     schema::{
         Binding, BindingSource, BindingSourceRef, BindingTarget, CapabilityKind, ChildTemplateDecl,
         ChildTemplateManifestDecl, ComponentDecl, ConfigSchema, EnvironmentDecl, ExportTarget,
-        LocalCapabilityRefKind, LocalComponentRef, ManifestBinding, MountSource, Program,
-        ProvideDecl, RawBinding, RawExportTarget, RawProgram, ResourceDecl, SlotDecl, VmScalarU32,
+        LocalCapabilityRefKind, LocalComponentRef, ManifestBinding, MountSource, PolicyRef,
+        Program, ProvideDecl, RawBinding, RawExportTarget, RawProgram, ResourceDecl, SlotDecl,
+        VmScalarU32,
     },
 };
 
@@ -43,6 +44,9 @@ pub struct RawManifest {
     #[serde_as(as = "MapPreventDuplicates<_, _>")]
     #[serde(default)]
     pub components: BTreeMap<String, ComponentDecl>,
+    #[serde_as(as = "MapPreventDuplicates<_, _>")]
+    #[serde(default)]
+    pub r#use: BTreeMap<String, ComponentDecl>,
 
     /// Optional named resolution environments for resolving child manifests.
     #[serde_as(as = "MapPreventDuplicates<_, _>")]
@@ -65,6 +69,8 @@ pub struct RawManifest {
     pub child_templates: BTreeMap<String, ChildTemplateDecl>,
     #[serde(default)]
     pub bindings: Vec<RawBinding>,
+    #[serde(default)]
+    pub policies: Vec<PolicyRef>,
     #[serde_as(as = "MapPreventDuplicates<_, _>")]
     #[serde(default)]
     pub exports: BTreeMap<String, RawExportTarget>,
@@ -78,6 +84,7 @@ pub struct RawManifest {
 pub enum ExperimentalFeature {
     Docker,
     Kvm,
+    Policies,
 }
 
 impl fmt::Display for ExperimentalFeature {
@@ -85,6 +92,7 @@ impl fmt::Display for ExperimentalFeature {
         match self {
             ExperimentalFeature::Docker => f.write_str("docker"),
             ExperimentalFeature::Kvm => f.write_str("kvm"),
+            ExperimentalFeature::Policies => f.write_str("policies"),
         }
     }
 }
@@ -179,6 +187,28 @@ fn validate_component_manifest_refs(
             ComponentDecl::Reference(reference) => validate_manifest_ref(reference)?,
             ComponentDecl::Object(obj) => validate_manifest_ref(&obj.manifest)?,
         }
+    }
+    Ok(())
+}
+
+fn validate_policy_refs(
+    uses: &BTreeMap<String, ComponentDecl>,
+    policies: &[PolicyRef],
+) -> Result<(), Error> {
+    for policy in policies {
+        if !uses.contains_key(policy.alias.as_str()) {
+            return Err(Error::UnknownPolicyUse {
+                alias: policy.alias.clone(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_use_names(uses: &BTreeMap<String, ComponentDecl>) -> Result<(), Error> {
+    for name in uses.keys() {
+        ensure_name_no_dot(name, "use")?;
     }
     Ok(())
 }
@@ -315,6 +345,24 @@ fn validate_component_environments(
     Ok(())
 }
 
+fn validate_use_environments(
+    uses: &BTreeMap<String, ComponentDecl>,
+    environments: &BTreeMap<String, EnvironmentDecl>,
+) -> Result<(), Error> {
+    for (use_name, decl) in uses {
+        if let ComponentDecl::Object(obj) = decl
+            && let Some(env) = obj.environment.as_deref()
+            && !environments.contains_key(env)
+        {
+            return Err(Error::UnknownUseEnvironment {
+                name: use_name.to_string(),
+                environment: env.to_string(),
+            });
+        }
+    }
+    Ok(())
+}
+
 fn validate_no_ambiguous_capability(
     slots: &BTreeMap<SlotName, SlotDecl>,
     provides: &BTreeMap<ProvideName, ProvideDecl>,
@@ -429,6 +477,21 @@ fn require_framework_capability_feature(
     Err(Error::FrameworkCapabilityRequiresFeature {
         capability: capability.to_string(),
         feature: feature.to_string(),
+    })
+}
+
+fn require_section_feature(
+    section: &'static str,
+    required_feature: ExperimentalFeature,
+    enabled_features: &BTreeSet<ExperimentalFeature>,
+) -> Result<(), Error> {
+    if enabled_features.contains(&required_feature) {
+        return Ok(());
+    }
+
+    Err(Error::SectionRequiresFeature {
+        section,
+        feature: required_feature.to_string(),
     })
 }
 
@@ -830,6 +893,7 @@ impl RawManifest {
             experimental_features,
             program,
             components,
+            r#use,
             environments,
             config_schema,
             slots,
@@ -837,6 +901,7 @@ impl RawManifest {
             resources,
             child_templates,
             bindings,
+            policies,
             exports,
             metadata,
         } = self;
@@ -848,11 +913,25 @@ impl RawManifest {
 
         validate_program_syntax_manifest_version(&manifest_version, program.as_ref())?;
 
+        if !r#use.is_empty() {
+            require_section_feature("use", ExperimentalFeature::Policies, &experimental_features)?;
+        }
+        if !policies.is_empty() {
+            require_section_feature(
+                "policies",
+                ExperimentalFeature::Policies,
+                &experimental_features,
+            )?;
+        }
+
         if let Some(schema) = config_schema.as_ref() {
             ConfigSchema::validate_value(&schema.0)?;
         }
         validate_component_manifest_refs(&components)?;
+        validate_component_manifest_refs(&r#use)?;
+        validate_use_names(&r#use)?;
         validate_environment_names(&environments)?;
+        validate_policy_refs(&r#use, &policies)?;
 
         let components = convert_components(components)?;
         let slots = convert_slots(slots)?;
@@ -863,6 +942,7 @@ impl RawManifest {
         validate_environment_extends(&environments)?;
         validate_environment_cycles(&environments)?;
         validate_component_environments(&components, &environments)?;
+        validate_use_environments(&r#use, &environments)?;
         validate_no_ambiguous_capability(&slots, &provides)?;
         validate_resource_decls(&resources)?;
         validate_child_templates(&child_templates, &slots, &bindings)?;
@@ -911,6 +991,7 @@ impl RawManifest {
             experimental_features,
             program,
             components,
+            r#use,
             environments,
             config_schema,
             slots,
@@ -918,6 +999,7 @@ impl RawManifest {
             resources,
             child_templates,
             bindings: bindings_out,
+            policies,
             exports: exports_out,
             metadata,
             digest: ManifestDigest::new([0; 32]),
@@ -934,6 +1016,7 @@ pub struct Manifest {
     experimental_features: BTreeSet<ExperimentalFeature>,
     program: Option<Program>,
     components: BTreeMap<ChildName, ComponentDecl>,
+    r#use: BTreeMap<String, ComponentDecl>,
     environments: BTreeMap<String, EnvironmentDecl>,
     config_schema: Option<ConfigSchema>,
     slots: BTreeMap<SlotName, SlotDecl>,
@@ -941,6 +1024,7 @@ pub struct Manifest {
     resources: BTreeMap<ResourceName, ResourceDecl>,
     child_templates: BTreeMap<TemplateName, ChildTemplateDecl>,
     bindings: Vec<ManifestBinding>,
+    policies: Vec<PolicyRef>,
     exports: BTreeMap<ExportName, ExportTarget>,
     metadata: Option<Value>,
     digest: ManifestDigest,
@@ -965,6 +1049,10 @@ impl Manifest {
 
     pub fn components(&self) -> &BTreeMap<ChildName, ComponentDecl> {
         &self.components
+    }
+
+    pub fn uses(&self) -> &BTreeMap<String, ComponentDecl> {
+        &self.r#use
     }
 
     pub fn environments(&self) -> &BTreeMap<String, EnvironmentDecl> {
@@ -995,6 +1083,10 @@ impl Manifest {
         &self.bindings
     }
 
+    pub fn policies(&self) -> &[PolicyRef] {
+        &self.policies
+    }
+
     pub fn exports(&self) -> &BTreeMap<ExportName, ExportTarget> {
         &self.exports
     }
@@ -1005,6 +1097,7 @@ impl Manifest {
             experimental_features: BTreeSet::new(),
             program: None,
             components: BTreeMap::new(),
+            r#use: BTreeMap::new(),
             environments: BTreeMap::new(),
             config_schema: None,
             slots: BTreeMap::new(),
@@ -1012,6 +1105,7 @@ impl Manifest {
             resources: BTreeMap::new(),
             child_templates: BTreeMap::new(),
             bindings: Vec::new(),
+            policies: Vec::new(),
             exports: BTreeMap::new(),
             metadata: None,
         }
@@ -1036,6 +1130,7 @@ impl Manifest {
         #[builder(default)] experimental_features: BTreeSet<ExperimentalFeature>,
         program: Option<Program>,
         #[builder(default)] components: BTreeMap<String, ComponentDecl>,
+        #[builder(default)] r#use: BTreeMap<String, ComponentDecl>,
         #[builder(default)] environments: BTreeMap<String, EnvironmentDecl>,
         config_schema: Option<Value>,
         #[builder(default)] slots: BTreeMap<String, SlotDecl>,
@@ -1043,6 +1138,7 @@ impl Manifest {
         #[builder(default)] resources: BTreeMap<String, ResourceDecl>,
         #[builder(default)] child_templates: BTreeMap<String, ChildTemplateDecl>,
         #[builder(default)] bindings: Vec<RawBinding>,
+        #[builder(default)] policies: Vec<PolicyRef>,
         #[builder(default)] exports: BTreeMap<String, RawExportTarget>,
         metadata: Option<Value>,
     ) -> Result<Self, Error> {
@@ -1053,6 +1149,7 @@ impl Manifest {
             experimental_features,
             program: program.map(RawProgram::from),
             components,
+            r#use,
             environments,
             config_schema,
             slots,
@@ -1060,6 +1157,7 @@ impl Manifest {
             resources,
             child_templates,
             bindings,
+            policies,
             exports,
             metadata,
         }
@@ -1088,6 +1186,8 @@ impl From<&Manifest> for RawManifest {
             .iter()
             .map(|(name, decl)| (name.to_string(), decl.clone()))
             .collect();
+
+        let uses = manifest.r#use.clone();
 
         let slots = manifest
             .slots
@@ -1186,6 +1286,7 @@ impl From<&Manifest> for RawManifest {
             experimental_features: manifest.experimental_features.clone(),
             program: manifest.program.as_ref().map(RawProgram::from),
             components,
+            r#use: uses,
             environments: manifest.environments.clone(),
             config_schema: manifest.config_schema.clone(),
             slots,
@@ -1193,6 +1294,7 @@ impl From<&Manifest> for RawManifest {
             resources,
             child_templates,
             bindings,
+            policies: manifest.policies.clone(),
             exports,
             metadata: manifest.metadata.clone(),
         }

--- a/compiler/manifest/src/manifest/tests/basics.rs
+++ b/compiler/manifest/src/manifest/tests/basics.rs
@@ -20,7 +20,7 @@ fn experimental_features_parse() {
     let manifest: Manifest = r#"
         {
           manifest_version: "0.1.0",
-          experimental_features: ["docker", "policies"],
+          experimental_features: ["docker", "governance"],
         }
         "#
     .parse()
@@ -34,7 +34,7 @@ fn experimental_features_parse() {
     assert!(
         manifest
             .experimental_features()
-            .contains(&ExperimentalFeature::Policies)
+            .contains(&ExperimentalFeature::Governance)
     );
 }
 

--- a/compiler/manifest/src/manifest/tests/basics.rs
+++ b/compiler/manifest/src/manifest/tests/basics.rs
@@ -20,7 +20,7 @@ fn experimental_features_parse() {
     let manifest: Manifest = r#"
         {
           manifest_version: "0.1.0",
-          experimental_features: ["docker"],
+          experimental_features: ["docker", "policies"],
         }
         "#
     .parse()
@@ -30,6 +30,11 @@ fn experimental_features_parse() {
         manifest
             .experimental_features()
             .contains(&ExperimentalFeature::Docker)
+    );
+    assert!(
+        manifest
+            .experimental_features()
+            .contains(&ExperimentalFeature::Policies)
     );
 }
 

--- a/compiler/manifest/src/manifest/tests/mod.rs
+++ b/compiler/manifest/src/manifest/tests/mod.rs
@@ -7,6 +7,7 @@ mod child_templates;
 mod components;
 mod exports;
 mod mounts;
+mod policies;
 
 fn parse_raw(input: &str) -> RawManifest {
     amber_json5::parse(input).unwrap()

--- a/compiler/manifest/src/manifest/tests/policies.rs
+++ b/compiler/manifest/src/manifest/tests/policies.rs
@@ -1,0 +1,172 @@
+use super::*;
+
+#[test]
+fn use_entries_and_policies_parse() {
+    let manifest: Manifest = r##"
+        {
+          manifest_version: "0.1.0",
+          experimental_features: ["policies"],
+          use: {
+            wrapper: "https://example.com/wrapper.json5",
+            membrane: { manifest: "https://example.com/membrane.json5", config: { level: "info" } },
+          },
+          policies: ["#wrapper.rewrite", "#membrane.apply"],
+        }
+        "##
+    .parse()
+    .unwrap();
+
+    assert_eq!(manifest.uses().len(), 2);
+    assert_eq!(manifest.policies().len(), 2);
+    assert_eq!(manifest.policies()[0].alias, "wrapper");
+    assert_eq!(manifest.policies()[0].export, "rewrite");
+    assert_eq!(manifest.policies()[1].alias, "membrane");
+    assert_eq!(manifest.policies()[1].export, "apply");
+}
+
+#[test]
+fn policy_ref_must_use_hash_alias_export_syntax() {
+    let err = r##"
+        {
+          manifest_version: "0.1.0",
+          experimental_features: ["policies"],
+          use: {
+            wrapper: "https://example.com/wrapper.json5",
+          },
+          policies: ["wrapper.rewrite"],
+        }
+        "##
+    .parse::<Manifest>()
+    .unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("invalid policy ref `wrapper.rewrite`"),
+        "expected invalid policy ref error, got: {err}"
+    );
+}
+
+#[test]
+fn policy_ref_alias_must_exist_in_use_map() {
+    let err = parse_raw(
+        r##"
+        {
+          manifest_version: "0.1.0",
+          experimental_features: ["policies"],
+          use: {
+            wrapper: "https://example.com/wrapper.json5",
+          },
+          policies: ["#missing.rewrite"],
+        }
+        "##,
+    )
+    .validate()
+    .unwrap_err();
+
+    match err {
+        Error::UnknownPolicyUse { alias } => assert_eq!(alias, "missing"),
+        other => panic!("expected UnknownPolicyUse error, got: {other}"),
+    }
+}
+
+#[test]
+fn use_requires_policies_experimental_feature() {
+    let err = parse_raw(
+        r#"
+        {
+          manifest_version: "0.1.0",
+          use: {
+            wrapper: "https://example.com/wrapper.json5",
+          },
+        }
+        "#,
+    )
+    .validate()
+    .unwrap_err();
+
+    match err {
+        Error::SectionRequiresFeature { section, feature } => {
+            assert_eq!(section, "use");
+            assert_eq!(feature, "policies");
+        }
+        other => panic!("expected SectionRequiresFeature error, got: {other}"),
+    }
+}
+
+#[test]
+fn policies_require_policies_experimental_feature() {
+    let err = parse_raw(
+        r##"
+        {
+          manifest_version: "0.1.0",
+          policies: ["#wrapper.rewrite"],
+        }
+        "##,
+    )
+    .validate()
+    .unwrap_err();
+
+    match err {
+        Error::SectionRequiresFeature { section, feature } => {
+            assert_eq!(section, "policies");
+            assert_eq!(feature, "policies");
+        }
+        other => panic!("expected SectionRequiresFeature error, got: {other}"),
+    }
+}
+
+#[test]
+fn use_names_must_not_contain_dots() {
+    let err = parse_raw(
+        r#"
+        {
+          manifest_version: "0.1.0",
+          experimental_features: ["policies"],
+          use: {
+            "wrap.per": "https://example.com/wrapper.json5",
+          },
+        }
+        "#,
+    )
+    .validate()
+    .unwrap_err();
+
+    match err {
+        Error::InvalidName { kind, name } => {
+            assert_eq!(kind, "use");
+            assert_eq!(name, "wrap.per");
+        }
+        other => panic!("expected InvalidName error, got: {other}"),
+    }
+}
+
+#[test]
+fn use_environment_reference_must_exist() {
+    let err = parse_raw(
+        r#"
+        {
+          manifest_version: "0.1.0",
+          experimental_features: ["policies"],
+          use: {
+            wrapper: {
+              manifest: "https://example.com/wrapper.json5",
+              environment: "missing",
+            },
+          },
+          environments: {
+            present: { resolvers: ["x"] },
+          },
+        }
+        "#,
+    )
+    .validate()
+    .unwrap_err();
+
+    match err {
+        Error::UnknownUseEnvironment { name, environment } => {
+            assert_eq!(name, "wrapper");
+            assert_eq!(environment, "missing");
+        }
+        other => panic!("expected UnknownUseEnvironment error, got: {other}"),
+    }
+}

--- a/compiler/manifest/src/manifest/tests/policies.rs
+++ b/compiler/manifest/src/manifest/tests/policies.rs
@@ -5,7 +5,7 @@ fn use_entries_and_policies_parse() {
     let manifest: Manifest = r##"
         {
           manifest_version: "0.1.0",
-          experimental_features: ["policies"],
+          experimental_features: ["governance"],
           use: {
             wrapper: "https://example.com/wrapper.json5",
             membrane: { manifest: "https://example.com/membrane.json5", config: { level: "info" } },
@@ -29,7 +29,7 @@ fn policy_ref_must_use_hash_alias_export_syntax() {
     let err = r##"
         {
           manifest_version: "0.1.0",
-          experimental_features: ["policies"],
+          experimental_features: ["governance"],
           use: {
             wrapper: "https://example.com/wrapper.json5",
           },
@@ -52,7 +52,7 @@ fn policy_ref_alias_must_exist_in_use_map() {
         r##"
         {
           manifest_version: "0.1.0",
-          experimental_features: ["policies"],
+          experimental_features: ["governance"],
           use: {
             wrapper: "https://example.com/wrapper.json5",
           },
@@ -87,7 +87,7 @@ fn use_requires_policies_experimental_feature() {
     match err {
         Error::SectionRequiresFeature { section, feature } => {
             assert_eq!(section, "use");
-            assert_eq!(feature, "policies");
+            assert_eq!(feature, "governance");
         }
         other => panic!("expected SectionRequiresFeature error, got: {other}"),
     }
@@ -109,7 +109,7 @@ fn policies_require_policies_experimental_feature() {
     match err {
         Error::SectionRequiresFeature { section, feature } => {
             assert_eq!(section, "policies");
-            assert_eq!(feature, "policies");
+            assert_eq!(feature, "governance");
         }
         other => panic!("expected SectionRequiresFeature error, got: {other}"),
     }
@@ -121,7 +121,7 @@ fn use_names_must_not_contain_dots() {
         r#"
         {
           manifest_version: "0.1.0",
-          experimental_features: ["policies"],
+          experimental_features: ["governance"],
           use: {
             "wrap.per": "https://example.com/wrapper.json5",
           },
@@ -146,7 +146,7 @@ fn use_environment_reference_must_exist() {
         r#"
         {
           manifest_version: "0.1.0",
-          experimental_features: ["policies"],
+          experimental_features: ["governance"],
           use: {
             wrapper: {
               manifest: "https://example.com/wrapper.json5",

--- a/compiler/manifest/src/schema.rs
+++ b/compiler/manifest/src/schema.rs
@@ -697,6 +697,30 @@ impl FromStr for RawExportTarget {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash, DeserializeFromStr, SerializeDisplay)]
+#[non_exhaustive]
+pub struct PolicyRef {
+    pub alias: String,
+    pub export: String,
+}
+
+impl fmt::Display for PolicyRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("#")?;
+        f.write_str(&self.alias)?;
+        f.write_str(".")?;
+        f.write_str(&self.export)
+    }
+}
+
+impl FromStr for PolicyRef {
+    type Err = Error;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        parse_policy_ref(input)
+    }
+}
+
 #[derive(
     Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, bon::Builder,
 )]
@@ -1158,6 +1182,35 @@ fn split_binding_source(input: &str) -> Result<(BindingSourceRef, String), Error
     let source = parse_binding_source_ref(left)?;
     ensure_binding_ref_name_no_dot(right, input)?;
     Ok((source, right.to_string()))
+}
+
+fn parse_policy_ref(input: &str) -> Result<PolicyRef, Error> {
+    let Some(rest) = input.strip_prefix('#') else {
+        return Err(Error::InvalidPolicyRef {
+            input: input.to_string(),
+            message: "expected `#<use>.<export>`".to_string(),
+        });
+    };
+    let Some((alias, export)) = rest.split_once('.') else {
+        return Err(Error::InvalidPolicyRef {
+            input: input.to_string(),
+            message: "expected `#<use>.<export>`".to_string(),
+        });
+    };
+    if alias.is_empty() || export.is_empty() || export.contains('.') {
+        return Err(Error::InvalidPolicyRef {
+            input: input.to_string(),
+            message: "expected `#<use>.<export>`".to_string(),
+        });
+    }
+
+    crate::names::ensure_name_no_dot(alias, "use")?;
+    crate::names::ensure_name_no_dot(export, "export")?;
+
+    Ok(PolicyRef {
+        alias: alias.to_string(),
+        export: export.to_string(),
+    })
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/compiler/manifest/src/spans.rs
+++ b/compiler/manifest/src/spans.rs
@@ -10,9 +10,11 @@ use serde_json::{Map, Value};
 pub struct ManifestSpans {
     pub manifest_version: Option<SourceSpan>,
     pub experimental_features: Option<SourceSpan>,
+    pub use_section: Option<SourceSpan>,
     pub program: Option<ProgramSpans>,
     pub config_schema: Option<SourceSpan>,
     pub components: HashMap<Arc<str>, ComponentDeclSpans>,
+    pub uses: HashMap<Arc<str>, ComponentDeclSpans>,
     pub environments: HashMap<Arc<str>, EnvironmentSpans>,
     pub slots: HashMap<Arc<str>, CapabilityDeclSpans>,
     pub slots_section: Option<SourceSpan>,
@@ -20,6 +22,7 @@ pub struct ManifestSpans {
     pub resources: HashMap<Arc<str>, ResourceDeclSpans>,
     pub bindings: HashMap<BindingTargetKey, BindingSpans>,
     pub bindings_by_index: Vec<BindingSpans>,
+    pub policies: Vec<PolicyRefSpans>,
     pub exports: HashMap<Arc<str>, ExportSpans>,
 }
 
@@ -58,6 +61,12 @@ pub struct ComponentDeclSpans {
     pub environment: Option<SourceSpan>,
     pub config: Option<SourceSpan>,
     pub config_key: Option<SourceSpan>,
+}
+
+#[derive(Clone, Debug)]
+pub struct PolicyRefSpans {
+    pub whole: SourceSpan,
+    pub value: Option<Arc<str>>,
 }
 
 #[derive(Clone, Debug)]
@@ -268,6 +277,7 @@ pub(crate) fn parse_manifest_spans(source: &str) -> Option<ManifestSpans> {
     let mut out = ManifestSpans {
         manifest_version: root.child_span("manifest_version"),
         experimental_features: root.child_span("experimental_features"),
+        use_section: root.child_span("use"),
         config_schema: root.child_span("config_schema"),
         ..ManifestSpans::default()
     };
@@ -283,11 +293,13 @@ pub(crate) fn parse_manifest_spans(source: &str) -> Option<ManifestSpans> {
     }
 
     collect_components(&root, root_obj, &mut out);
+    collect_uses(&root, root_obj, &mut out);
     collect_environments(&root, root_obj, &mut out);
     collect_slots(&root, root_obj, &mut out);
     collect_provides(&root, root_obj, &mut out);
     collect_resources(&root, root_obj, &mut out);
     collect_bindings(&root, root_obj, &mut out);
+    collect_policies(&root, root_obj, &mut out);
     collect_exports(&root, root_obj, &mut out);
 
     Some(out)
@@ -298,7 +310,20 @@ fn collect_components(
     root_obj: &Map<String, Value>,
     out: &mut ManifestSpans,
 ) {
-    let Some((components, components_obj)) = object_section(root, root_obj, "components") else {
+    collect_component_like_section(root, root_obj, "components", &mut out.components);
+}
+
+fn collect_uses(root: &SpanCursor<'_>, root_obj: &Map<String, Value>, out: &mut ManifestSpans) {
+    collect_component_like_section(root, root_obj, "use", &mut out.uses);
+}
+
+fn collect_component_like_section(
+    root: &SpanCursor<'_>,
+    root_obj: &Map<String, Value>,
+    key: &str,
+    out: &mut HashMap<Arc<str>, ComponentDeclSpans>,
+) {
+    let Some((components, components_obj)) = object_section(root, root_obj, key) else {
         return;
     };
 
@@ -340,7 +365,7 @@ fn collect_components(
             _ => {}
         }
 
-        out.components.insert(name.as_str().into(), spans);
+        out.insert(name.as_str().into(), spans);
     }
 }
 
@@ -552,6 +577,20 @@ fn collect_exports(root: &SpanCursor<'_>, root_obj: &Map<String, Value>, out: &m
                 target_value,
             },
         );
+    }
+}
+
+fn collect_policies(root: &SpanCursor<'_>, root_obj: &Map<String, Value>, out: &mut ManifestSpans) {
+    let Some((policies, policy_values)) = array_section(root, root_obj, "policies") else {
+        return;
+    };
+
+    for (idx, policy_value) in policy_values.iter().enumerate() {
+        let whole = span_or_default(policies.index_span(idx));
+        out.policies.push(PolicyRefSpans {
+            whole,
+            value: policy_value.as_str().map(Into::into),
+        });
     }
 }
 

--- a/compiler/src/bundle/mod.rs
+++ b/compiler/src/bundle/mod.rs
@@ -426,6 +426,9 @@ fn collect_bundle_requests(
     for child in node.children.values() {
         collect_bundle_requests(child, store, requests_by_url, source_url_by_digest)?;
     }
+    for used in node.uses.values() {
+        collect_bundle_requests(used, store, requests_by_url, source_url_by_digest)?;
+    }
 
     Ok(())
 }

--- a/compiler/src/frontend/mod.rs
+++ b/compiler/src/frontend/mod.rs
@@ -581,13 +581,13 @@ fn resolve_policies(
     uses: &BTreeMap<String, ResolvedNode>,
 ) -> Result<Vec<ResolvedPolicy>, Error> {
     let mut resolved = Vec::with_capacity(manifest.policies().len());
-    for policy in manifest.policies() {
+    for (policy_index, policy) in manifest.policies().iter().enumerate() {
         let use_node = uses
             .get(policy.alias.as_str())
             .expect("policy aliases are validated before resolution");
         let endpoint =
             resolve_policy_export(svc, use_node, policy.export.as_str()).map_err(|()| {
-                let (src, span) = policy_ref_decl_site(svc, manifest_url, policy);
+                let (src, span) = policy_ref_decl_site(svc, manifest_url, policy_index);
                 Error::PolicyExportUnresolved {
                     policy: policy.to_string().into(),
                     use_name: policy.alias.clone().into(),
@@ -608,7 +608,7 @@ fn resolve_policies(
                 });
             }
             ResolvedPolicyEndpoint::Provide { decl, .. } => {
-                let (src, span) = policy_ref_decl_site(svc, manifest_url, policy);
+                let (src, span) = policy_ref_decl_site(svc, manifest_url, policy_index);
                 return Err(Error::InvalidPolicyExport {
                     policy: policy.to_string().into(),
                     message: format!(
@@ -621,7 +621,7 @@ fn resolve_policies(
                 });
             }
             ResolvedPolicyEndpoint::Slot { .. } => {
-                let (src, span) = policy_ref_decl_site(svc, manifest_url, policy);
+                let (src, span) = policy_ref_decl_site(svc, manifest_url, policy_index);
                 return Err(Error::InvalidPolicyExport {
                     policy: policy.to_string().into(),
                     message: "must resolve to a provide, not a slot".into(),
@@ -720,16 +720,14 @@ fn use_manifest_decl_site(
 fn policy_ref_decl_site(
     svc: &ResolveService,
     manifest_url: &Url,
-    policy: &PolicyRef,
+    policy_index: usize,
 ) -> (Option<NamedSource<Arc<str>>>, Option<SourceSpan>) {
-    let policy_ref = policy.to_string();
     svc.store
         .diagnostic_source(manifest_url)
         .map_or((None, None), |(src, spans)| {
             let span = spans
                 .policies
-                .iter()
-                .find(|candidate| candidate.value.as_deref() == Some(policy_ref.as_str()))
+                .get(policy_index)
                 .map(|candidate| candidate.whole)
                 .unwrap_or((0usize, 0usize).into());
             (Some(src), Some(span))

--- a/compiler/src/frontend/mod.rs
+++ b/compiler/src/frontend/mod.rs
@@ -14,8 +14,8 @@ use std::{
 };
 
 use amber_manifest::{
-    ChildTemplateDecl, ChildTemplateManifestDecl, ComponentDecl, ExperimentalFeature, Manifest,
-    ManifestDigest, ManifestRef,
+    CapabilityDecl, CapabilityKind, ChildTemplateDecl, ChildTemplateManifestDecl, ComponentDecl,
+    ExperimentalFeature, Manifest, ManifestDigest, ManifestRef, PolicyRef,
 };
 use amber_resolver::{self as resolver, RemoteResolver, Resolver};
 use futures::stream::StreamExt;
@@ -84,10 +84,10 @@ pub enum Error {
     #[diagnostic(code(compiler::relative_manifest_ref))]
     RelativeManifestRef { reference: Box<str> },
 
-    #[error("invalid manifest reference `{reference}` in {realm_url}: {message}")]
+    #[error("invalid manifest reference `{reference}` in {manifest_url}: {message}")]
     #[diagnostic(code(compiler::invalid_manifest_ref))]
     InvalidManifestRef {
-        realm_url: Box<Url>,
+        manifest_url: Box<Url>,
         reference: Box<str>,
         message: Box<str>,
         #[source_code]
@@ -98,11 +98,11 @@ pub enum Error {
 
     #[error(
         "failed to resolve manifest reference `{reference}` for component `#{child}` in \
-         {realm_path}: {message}"
+         {manifest_path}: {message}"
     )]
     #[diagnostic(code(compiler::manifest_ref_resolution))]
     ManifestRefResolution {
-        realm_path: Box<str>,
+        manifest_path: Box<str>,
         child: Box<str>,
         reference: Box<str>,
         message: Box<str>,
@@ -113,11 +113,11 @@ pub enum Error {
     },
 
     #[error(
-        "unknown resolver `{resolver}` referenced by environment `{environment}` in {realm_url}"
+        "unknown resolver `{resolver}` referenced by environment `{environment}` in {manifest_url}"
     )]
     #[diagnostic(code(compiler::unknown_resolver))]
     UnknownResolver {
-        realm_url: Box<Url>,
+        manifest_url: Box<Url>,
         environment: Box<str>,
         resolver: Box<str>,
         #[source_code]
@@ -143,6 +143,40 @@ pub enum Error {
         #[source_code]
         src: Option<NamedSource<Arc<str>>>,
         #[label(primary, "child declaration here")]
+        span: Option<SourceSpan>,
+        #[related]
+        related: Vec<RelatedManifestSpan>,
+    },
+
+    #[error("policy `{policy}` could not resolve export `{export}` from use `#{use_name}`")]
+    #[diagnostic(
+        code(compiler::policy_export_unresolved),
+        help(
+            "Ensure the used manifest exports this capability and that any child export chain \
+             resolves to a real export."
+        )
+    )]
+    PolicyExportUnresolved {
+        policy: Box<str>,
+        use_name: Box<str>,
+        export: Box<str>,
+        #[source_code]
+        src: Option<NamedSource<Arc<str>>>,
+        #[label(primary, "policy referenced here")]
+        span: Option<SourceSpan>,
+    },
+
+    #[error("policy `{policy}` {message}")]
+    #[diagnostic(
+        code(compiler::invalid_policy_export),
+        help("Policy refs must resolve to an exported `http` provide with profile `policy`.")
+    )]
+    InvalidPolicyExport {
+        policy: Box<str>,
+        message: Box<str>,
+        #[source_code]
+        src: Option<NamedSource<Arc<str>>>,
+        #[label(primary, "policy referenced here")]
         span: Option<SourceSpan>,
         #[related]
         related: Vec<RelatedManifestSpan>,
@@ -180,7 +214,27 @@ pub struct ResolvedNode {
     pub config: Option<serde_json::Value>,
     pub children: BTreeMap<String, ResolvedNode>,
     pub uses: BTreeMap<String, ResolvedNode>,
+    pub policies: Vec<ResolvedPolicy>,
     pub child_templates: BTreeMap<String, ResolvedChildTemplate>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ResolvedPolicy {
+    pub reference: PolicyRef,
+    pub capability: CapabilityDecl,
+}
+
+#[derive(Clone, Debug)]
+enum ResolvedPolicyEndpoint {
+    Provide {
+        name: String,
+        decl: CapabilityDecl,
+        resolved_url: Url,
+    },
+    Slot {
+        name: String,
+        resolved_url: Url,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -318,7 +372,7 @@ async fn resolve_component(
                     });
 
             Error::InvalidManifestRef {
-                realm_url: Box::new(base.clone()),
+                manifest_url: Box::new(base.clone()),
                 reference: declared_ref.url.as_str().into(),
                 message: err.to_string().into(),
                 src,
@@ -360,12 +414,19 @@ async fn resolve_component(
         .filter_map(component_decl_environment)
         .collect();
 
-    let realm_url = resolved_url.clone();
+    let manifest_url = resolved_url.clone();
     let parent_features = manifest.experimental_features().clone();
 
     let mut env_cache: HashMap<String, Arc<ResolveEnv>> = HashMap::new();
     for env_name in &referenced_envs {
-        let _ = compute_environment(&svc, &env, &manifest, &realm_url, env_name, &mut env_cache)?;
+        let _ = compute_environment(
+            &svc,
+            &env,
+            &manifest,
+            &manifest_url,
+            env_name,
+            &mut env_cache,
+        )?;
     }
 
     let children_futs: Vec<_> = manifest
@@ -378,7 +439,7 @@ async fn resolve_component(
             let parent_features = parent_features.clone();
             let child_stack = stack.clone();
             let child_path_set = path_set.clone();
-            let realm_url = realm_url.clone();
+            let manifest_url = manifest_url.clone();
 
             let child_env = match child_env_name {
                 None => Arc::clone(&env),
@@ -392,7 +453,7 @@ async fn resolve_component(
                 let child_ctx = ResolveContext {
                     svc: Arc::clone(&svc),
                     env: child_env,
-                    base_url: Some(realm_url.clone()),
+                    base_url: Some(manifest_url.clone()),
                     stack: child_stack,
                     path_set: child_path_set,
                 };
@@ -400,7 +461,7 @@ async fn resolve_component(
                     resolve_component(child_ctx, child_name.clone(), child_ref, child_cfg).await?;
                 validate_child_experimental_features(
                     &svc,
-                    &realm_url,
+                    &manifest_url,
                     child_name.as_str(),
                     &parent_features,
                     child_node.digest,
@@ -430,7 +491,7 @@ async fn resolve_component(
             let parent_features = parent_features.clone();
             let use_stack = stack.clone();
             let use_path_set = path_set.clone();
-            let realm_url = realm_url.clone();
+            let manifest_url = manifest_url.clone();
 
             let use_env = match use_env_name {
                 None => Arc::clone(&env),
@@ -444,7 +505,7 @@ async fn resolve_component(
                 let use_ctx = ResolveContext {
                     svc: Arc::clone(&svc),
                     env: use_env,
-                    base_url: Some(realm_url.clone()),
+                    base_url: Some(manifest_url.clone()),
                     stack: use_stack,
                     path_set: use_path_set,
                 };
@@ -452,7 +513,7 @@ async fn resolve_component(
                     resolve_component(use_ctx, use_name.clone(), use_ref, use_cfg).await?;
                 validate_child_experimental_features(
                     &svc,
-                    &realm_url,
+                    &manifest_url,
                     use_name.as_str(),
                     &parent_features,
                     use_node.digest,
@@ -460,7 +521,7 @@ async fn resolve_component(
                 )?;
                 validate_use_root_slots(
                     &svc,
-                    &realm_url,
+                    &manifest_url,
                     use_name.as_str(),
                     use_node.digest,
                     &use_node.resolved_url,
@@ -478,11 +539,13 @@ async fn resolve_component(
         uses.insert(use_name, use_node);
     }
 
+    let policies = resolve_policies(&svc, &manifest, &manifest_url, &uses)?;
+
     let child_templates = resolve_child_templates(
         &svc,
         &env,
         &manifest,
-        &realm_url,
+        &manifest_url,
         &parent_features,
         &stack,
         &path_set,
@@ -498,6 +561,7 @@ async fn resolve_component(
         config,
         children,
         uses,
+        policies,
         child_templates,
     })
 }
@@ -510,13 +574,121 @@ fn component_decl_environment(decl: &ComponentDecl) -> Option<String> {
     }
 }
 
+fn resolve_policies(
+    svc: &ResolveService,
+    manifest: &Manifest,
+    manifest_url: &Url,
+    uses: &BTreeMap<String, ResolvedNode>,
+) -> Result<Vec<ResolvedPolicy>, Error> {
+    let mut resolved = Vec::with_capacity(manifest.policies().len());
+    for policy in manifest.policies() {
+        let use_node = uses
+            .get(policy.alias.as_str())
+            .expect("policy aliases are validated before resolution");
+        let endpoint =
+            resolve_policy_export(svc, use_node, policy.export.as_str()).map_err(|()| {
+                let (src, span) = policy_ref_decl_site(svc, manifest_url, policy);
+                Error::PolicyExportUnresolved {
+                    policy: policy.to_string().into(),
+                    use_name: policy.alias.clone().into(),
+                    export: policy.export.clone().into(),
+                    src,
+                    span,
+                }
+            })?;
+
+        match &endpoint {
+            ResolvedPolicyEndpoint::Provide { decl, .. }
+                if decl.kind == CapabilityKind::Http
+                    && decl.profile.as_deref() == Some("policy") =>
+            {
+                resolved.push(ResolvedPolicy {
+                    reference: policy.clone(),
+                    capability: decl.clone(),
+                });
+            }
+            ResolvedPolicyEndpoint::Provide { decl, .. } => {
+                let (src, span) = policy_ref_decl_site(svc, manifest_url, policy);
+                return Err(Error::InvalidPolicyExport {
+                    policy: policy.to_string().into(),
+                    message: format!(
+                        "must resolve to an `http` provide with profile `policy`, got `{decl}`"
+                    )
+                    .into(),
+                    src,
+                    span,
+                    related: policy_endpoint_related_spans(svc, policy, &endpoint),
+                });
+            }
+            ResolvedPolicyEndpoint::Slot { .. } => {
+                let (src, span) = policy_ref_decl_site(svc, manifest_url, policy);
+                return Err(Error::InvalidPolicyExport {
+                    policy: policy.to_string().into(),
+                    message: "must resolve to a provide, not a slot".into(),
+                    src,
+                    span,
+                    related: policy_endpoint_related_spans(svc, policy, &endpoint),
+                });
+            }
+        }
+    }
+
+    Ok(resolved)
+}
+
+fn resolve_policy_export(
+    svc: &ResolveService,
+    node: &ResolvedNode,
+    export_name: &str,
+) -> Result<ResolvedPolicyEndpoint, ()> {
+    let manifest = svc
+        .store
+        .get(&node.digest)
+        .expect("resolved policy manifest should be in the digest store");
+    let Some(target) = manifest.exports().get(export_name) else {
+        return Err(());
+    };
+
+    match target {
+        amber_manifest::ExportTarget::SelfProvide(provide_name) => {
+            let provide_decl = manifest
+                .provides()
+                .get(provide_name)
+                .expect("manifest invariant: exported provide exists");
+            Ok(ResolvedPolicyEndpoint::Provide {
+                name: provide_name.to_string(),
+                decl: provide_decl.decl.clone(),
+                resolved_url: node.resolved_url.clone(),
+            })
+        }
+        amber_manifest::ExportTarget::SelfSlot(slot_name) => {
+            manifest
+                .slots()
+                .get(slot_name)
+                .expect("manifest invariant: exported slot exists");
+            Ok(ResolvedPolicyEndpoint::Slot {
+                name: slot_name.to_string(),
+                resolved_url: node.resolved_url.clone(),
+            })
+        }
+        amber_manifest::ExportTarget::ChildExport { child, export } => {
+            let child_node = node
+                .children
+                .get(child.as_str())
+                .expect("manifest invariant: exported child exists");
+            resolve_policy_export(svc, child_node, export.as_str())
+        }
+        _ => Err(()),
+    }
+}
+
 fn child_manifest_decl_site(
     svc: &ResolveService,
-    realm_url: &Url,
+    manifest_url: &Url,
     child_name: &str,
 ) -> (Option<NamedSource<Arc<str>>>, Option<SourceSpan>) {
     svc.store
-        .diagnostic_source(realm_url)
+        .diagnostic_source(manifest_url)
         .map_or((None, None), |(src, spans)| {
             let span = spans
                 .components
@@ -530,11 +702,11 @@ fn child_manifest_decl_site(
 
 fn use_manifest_decl_site(
     svc: &ResolveService,
-    realm_url: &Url,
+    manifest_url: &Url,
     use_name: &str,
 ) -> (Option<NamedSource<Arc<str>>>, Option<SourceSpan>) {
     svc.store
-        .diagnostic_source(realm_url)
+        .diagnostic_source(manifest_url)
         .map_or((None, None), |(src, spans)| {
             let span = spans
                 .uses
@@ -545,9 +717,65 @@ fn use_manifest_decl_site(
         })
 }
 
+fn policy_ref_decl_site(
+    svc: &ResolveService,
+    manifest_url: &Url,
+    policy: &PolicyRef,
+) -> (Option<NamedSource<Arc<str>>>, Option<SourceSpan>) {
+    let policy_ref = policy.to_string();
+    svc.store
+        .diagnostic_source(manifest_url)
+        .map_or((None, None), |(src, spans)| {
+            let span = spans
+                .policies
+                .iter()
+                .find(|candidate| candidate.value.as_deref() == Some(policy_ref.as_str()))
+                .map(|candidate| candidate.whole)
+                .unwrap_or((0usize, 0usize).into());
+            (Some(src), Some(span))
+        })
+}
+
+fn policy_endpoint_related_spans(
+    svc: &ResolveService,
+    policy: &PolicyRef,
+    endpoint: &ResolvedPolicyEndpoint,
+) -> Vec<RelatedManifestSpan> {
+    let (resolved_url, name, label) = match endpoint {
+        ResolvedPolicyEndpoint::Provide {
+            resolved_url, name, ..
+        } => (resolved_url, name, "resolved provide declared here"),
+        ResolvedPolicyEndpoint::Slot {
+            resolved_url, name, ..
+        } => (resolved_url, name, "resolved slot declared here"),
+    };
+
+    let Some(stored) = svc.store.get_source(resolved_url) else {
+        return Vec::new();
+    };
+    let span = match endpoint {
+        ResolvedPolicyEndpoint::Provide { .. } => stored
+            .spans
+            .provides
+            .get(name.as_str())
+            .map(|provide| provide.capability.name),
+        ResolvedPolicyEndpoint::Slot { .. } => {
+            stored.spans.slots.get(name.as_str()).map(|slot| slot.name)
+        }
+    }
+    .unwrap_or((0usize, 0usize).into());
+
+    vec![RelatedManifestSpan {
+        message: format!("policy `{policy}` resolves here"),
+        src: NamedSource::new(display_url(resolved_url), stored.source).with_language("json5"),
+        span,
+        label: label.to_string(),
+    }]
+}
+
 fn wrap_child_manifest_resolution_error(
     svc: &ResolveService,
-    realm_url: Option<&Url>,
+    manifest_url: Option<&Url>,
     child_name: &str,
     declared_ref: &ManifestRef,
     err: Error,
@@ -559,13 +787,13 @@ fn wrap_child_manifest_resolution_error(
         return Error::Resolver(resolver_err);
     }
 
-    let Some(realm_url) = realm_url else {
+    let Some(manifest_url) = manifest_url else {
         return Error::Resolver(resolver_err);
     };
-    let (src, span) = child_manifest_decl_site(svc, realm_url, child_name);
+    let (src, span) = child_manifest_decl_site(svc, manifest_url, child_name);
 
     Error::ManifestRefResolution {
-        realm_path: display_url(realm_url).into(),
+        manifest_path: display_url(manifest_url).into(),
         child: child_name.into(),
         reference: declared_ref.url.as_str().into(),
         message: resolver_error_message(&resolver_err).into(),
@@ -596,7 +824,7 @@ async fn resolve_child_templates(
     svc: &Arc<ResolveService>,
     env: &Arc<ResolveEnv>,
     manifest: &Manifest,
-    realm_url: &Url,
+    manifest_url: &Url,
     parent_features: &BTreeSet<ExperimentalFeature>,
     stack: &[Url],
     path_set: &HashSet<ManifestDigest>,
@@ -604,13 +832,14 @@ async fn resolve_child_templates(
     let mut out = BTreeMap::new();
 
     for (template_name, decl) in manifest.child_templates() {
-        let refs = resolve_child_template_manifest_refs(realm_url, template_name.as_str(), decl)?;
+        let refs =
+            resolve_child_template_manifest_refs(manifest_url, template_name.as_str(), decl)?;
         let mut manifests = Vec::with_capacity(refs.len());
         for reference in refs {
             let child_ctx = ResolveContext {
                 svc: Arc::clone(svc),
                 env: Arc::clone(env),
-                base_url: Some(realm_url.clone()),
+                base_url: Some(manifest_url.clone()),
                 stack: stack.to_vec(),
                 path_set: path_set.clone(),
             };
@@ -623,7 +852,7 @@ async fn resolve_child_templates(
             .await?;
             validate_child_experimental_features(
                 svc,
-                realm_url,
+                manifest_url,
                 template_name.as_str(),
                 parent_features,
                 root.digest,
@@ -649,7 +878,7 @@ async fn resolve_child_templates(
 }
 
 fn resolve_child_template_manifest_refs(
-    realm_url: &Url,
+    manifest_url: &Url,
     template_name: &str,
     decl: &ChildTemplateDecl,
 ) -> Result<Vec<ManifestRef>, Error> {
@@ -657,14 +886,16 @@ fn resolve_child_template_manifest_refs(
         None => Ok(Vec::new()),
         Some(ChildTemplateManifestDecl::One(reference)) => {
             Ok(vec![resolve_manifest_ref_for_template(
-                realm_url,
+                manifest_url,
                 template_name,
                 reference,
             )?])
         }
         Some(ChildTemplateManifestDecl::Many(refs)) => refs
             .iter()
-            .map(|reference| resolve_manifest_ref_for_template(realm_url, template_name, reference))
+            .map(|reference| {
+                resolve_manifest_ref_for_template(manifest_url, template_name, reference)
+            })
             .collect(),
         Some(_) => {
             unreachable!("manifest validation handles unknown child-template manifest forms")
@@ -673,16 +904,16 @@ fn resolve_child_template_manifest_refs(
 }
 
 fn resolve_manifest_ref_for_template(
-    realm_url: &Url,
+    manifest_url: &Url,
     template_name: &str,
     reference: &ManifestRef,
 ) -> Result<ManifestRef, Error> {
     if !reference.url.is_relative() {
         return Ok(reference.clone());
     }
-    if realm_url.scheme() != "file" {
+    if manifest_url.scheme() != "file" {
         return Err(Error::ManifestRefResolution {
-            realm_path: display_url(realm_url).into(),
+            manifest_path: display_url(manifest_url).into(),
             child: template_name.into(),
             reference: reference.url.as_str().into(),
             message: "relative child template manifest references require a file:// owning \
@@ -693,9 +924,9 @@ fn resolve_manifest_ref_for_template(
         });
     }
     reference
-        .resolve_against(realm_url)
+        .resolve_against(manifest_url)
         .map_err(|err| Error::ManifestRefResolution {
-            realm_path: display_url(realm_url).into(),
+            manifest_path: display_url(manifest_url).into(),
             child: template_name.into(),
             reference: reference.url.as_str().into(),
             message: err.to_string().into(),
@@ -706,7 +937,7 @@ fn resolve_manifest_ref_for_template(
 
 fn validate_use_root_slots(
     svc: &ResolveService,
-    realm_url: &Url,
+    manifest_url: &Url,
     use_name: &str,
     digest: ManifestDigest,
     use_url: &Url,
@@ -725,7 +956,7 @@ fn validate_use_root_slots(
         return Ok(());
     }
 
-    let (src, span) = use_manifest_decl_site(svc, realm_url, use_name);
+    let (src, span) = use_manifest_decl_site(svc, manifest_url, use_name);
     let mut related = Vec::new();
     if let Some(stored) = svc.store.get_source(use_url) {
         for slot_name in &required_slots {
@@ -756,7 +987,7 @@ fn validate_use_root_slots(
 
 fn validate_child_experimental_features(
     svc: &ResolveService,
-    realm_url: &Url,
+    manifest_url: &Url,
     child_name: &str,
     parent_features: &BTreeSet<ExperimentalFeature>,
     child_digest: ManifestDigest,
@@ -778,7 +1009,7 @@ fn validate_child_experimental_features(
 
     let (src, span) =
         svc.store
-            .diagnostic_source(realm_url)
+            .diagnostic_source(manifest_url)
             .map_or((None, None), |(src, spans)| {
                 let span = spans
                     .components
@@ -817,7 +1048,7 @@ fn compute_environment(
     svc: &ResolveService,
     base_env: &Arc<ResolveEnv>,
     manifest: &Manifest,
-    realm_url: &Url,
+    manifest_url: &Url,
     env_name: &str,
     env_cache: &mut HashMap<String, Arc<ResolveEnv>>,
 ) -> Result<Arc<ResolveEnv>, Error> {
@@ -831,7 +1062,7 @@ fn compute_environment(
         .expect("environment names are validated in Manifest");
 
     let parent_env = if let Some(ext) = env_decl.extends.as_deref() {
-        compute_environment(svc, base_env, manifest, realm_url, ext, env_cache)?
+        compute_environment(svc, base_env, manifest, manifest_url, ext, env_cache)?
     } else {
         Arc::clone(base_env)
     };
@@ -841,7 +1072,7 @@ fn compute_environment(
         let Some(r) = svc.registry.get(resolver_name.as_str()) else {
             let (src, span) =
                 svc.store
-                    .diagnostic_source(realm_url)
+                    .diagnostic_source(manifest_url)
                     .map_or((None, None), |(src, spans)| {
                         let env = spans.environments.get(env_name);
                         let span = env
@@ -856,7 +1087,7 @@ fn compute_environment(
                         (Some(src), Some(span))
                     });
             return Err(Error::UnknownResolver {
-                realm_url: Box::new(realm_url.clone()),
+                manifest_url: Box::new(manifest_url.clone()),
                 environment: env_name.into(),
                 resolver: resolver_name.as_str().into(),
                 src,

--- a/compiler/src/frontend/mod.rs
+++ b/compiler/src/frontend/mod.rs
@@ -147,6 +147,22 @@ pub enum Error {
         #[related]
         related: Vec<RelatedManifestSpan>,
     },
+
+    #[error("use `#{name}` requires root slot(s) that the main scenario cannot bind: {slots}")]
+    #[diagnostic(
+        code(compiler::use_requires_root_slots),
+        help("Make these slots optional or move the required inputs inside the used manifest.")
+    )]
+    UseRequiresRootSlots {
+        name: Box<str>,
+        slots: Box<str>,
+        #[source_code]
+        src: Option<NamedSource<Arc<str>>>,
+        #[label(primary, "use declared here")]
+        span: Option<SourceSpan>,
+        #[related]
+        related: Vec<RelatedManifestSpan>,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -163,6 +179,7 @@ pub struct ResolvedNode {
     pub observed_url: Option<Url>,
     pub config: Option<serde_json::Value>,
     pub children: BTreeMap<String, ResolvedNode>,
+    pub uses: BTreeMap<String, ResolvedNode>,
     pub child_templates: BTreeMap<String, ResolvedChildTemplate>,
 }
 
@@ -294,6 +311,7 @@ async fn resolve_component(
                         let span = spans
                             .components
                             .get(name.as_str())
+                            .or_else(|| spans.uses.get(name.as_str()))
                             .and_then(|c| c.manifest)
                             .unwrap_or((0usize, 0usize).into());
                         (Some(src), Some(span))
@@ -338,6 +356,7 @@ async fn resolve_component(
     let referenced_envs: HashSet<String> = manifest
         .components()
         .values()
+        .chain(manifest.uses().values())
         .filter_map(component_decl_environment)
         .collect();
 
@@ -401,6 +420,64 @@ async fn resolve_component(
         children.insert(child_name, child_node);
     }
 
+    let uses_futs: Vec<_> = manifest
+        .uses()
+        .iter()
+        .map(|(use_name, decl)| {
+            let use_name = use_name.clone();
+            let (use_ref, use_cfg, use_env_name) = extract_component_decl(decl);
+            let svc = Arc::clone(&svc);
+            let parent_features = parent_features.clone();
+            let use_stack = stack.clone();
+            let use_path_set = path_set.clone();
+            let realm_url = realm_url.clone();
+
+            let use_env = match use_env_name {
+                None => Arc::clone(&env),
+                Some(env_name) => env_cache
+                    .get(&env_name)
+                    .cloned()
+                    .expect("referenced environment should be precomputed"),
+            };
+
+            async move {
+                let use_ctx = ResolveContext {
+                    svc: Arc::clone(&svc),
+                    env: use_env,
+                    base_url: Some(realm_url.clone()),
+                    stack: use_stack,
+                    path_set: use_path_set,
+                };
+                let use_node =
+                    resolve_component(use_ctx, use_name.clone(), use_ref, use_cfg).await?;
+                validate_child_experimental_features(
+                    &svc,
+                    &realm_url,
+                    use_name.as_str(),
+                    &parent_features,
+                    use_node.digest,
+                    &use_node.resolved_url,
+                )?;
+                validate_use_root_slots(
+                    &svc,
+                    &realm_url,
+                    use_name.as_str(),
+                    use_node.digest,
+                    &use_node.resolved_url,
+                )?;
+                Ok::<(String, ResolvedNode), Error>((use_name, use_node))
+            }
+        })
+        .collect();
+
+    let mut uses_stream = futures::stream::iter(uses_futs).buffer_unordered(svc.max_concurrency);
+
+    let mut uses = BTreeMap::new();
+    while let Some(res) = uses_stream.next().await {
+        let (use_name, use_node) = res?;
+        uses.insert(use_name, use_node);
+    }
+
     let child_templates = resolve_child_templates(
         &svc,
         &env,
@@ -420,6 +497,7 @@ async fn resolve_component(
         observed_url,
         config,
         children,
+        uses,
         child_templates,
     })
 }
@@ -443,6 +521,24 @@ fn child_manifest_decl_site(
             let span = spans
                 .components
                 .get(child_name)
+                .or_else(|| spans.uses.get(child_name))
+                .and_then(|component| component.manifest.or(Some(component.whole)))
+                .unwrap_or((0usize, 0usize).into());
+            (Some(src), Some(span))
+        })
+}
+
+fn use_manifest_decl_site(
+    svc: &ResolveService,
+    realm_url: &Url,
+    use_name: &str,
+) -> (Option<NamedSource<Arc<str>>>, Option<SourceSpan>) {
+    svc.store
+        .diagnostic_source(realm_url)
+        .map_or((None, None), |(src, spans)| {
+            let span = spans
+                .uses
+                .get(use_name)
                 .and_then(|component| component.manifest.or(Some(component.whole)))
                 .unwrap_or((0usize, 0usize).into());
             (Some(src), Some(span))
@@ -608,6 +704,56 @@ fn resolve_manifest_ref_for_template(
         })
 }
 
+fn validate_use_root_slots(
+    svc: &ResolveService,
+    realm_url: &Url,
+    use_name: &str,
+    digest: ManifestDigest,
+    use_url: &Url,
+) -> Result<(), Error> {
+    let manifest = svc
+        .store
+        .get(&digest)
+        .expect("used manifest should be in the digest store after resolution");
+    let required_slots: Vec<_> = manifest
+        .slots()
+        .iter()
+        .filter(|(_, slot)| !slot.optional)
+        .map(|(name, _)| name.to_string())
+        .collect();
+    if required_slots.is_empty() {
+        return Ok(());
+    }
+
+    let (src, span) = use_manifest_decl_site(svc, realm_url, use_name);
+    let mut related = Vec::new();
+    if let Some(stored) = svc.store.get_source(use_url) {
+        for slot_name in &required_slots {
+            let span = stored
+                .spans
+                .slots
+                .get(slot_name.as_str())
+                .map(|slot| slot.name)
+                .unwrap_or((0usize, 0usize).into());
+            related.push(RelatedManifestSpan {
+                message: format!("use `#{use_name}` requires slot `{slot_name}` here"),
+                src: NamedSource::new(display_url(use_url), stored.source.clone())
+                    .with_language("json5"),
+                span,
+                label: "required slot declared here".to_string(),
+            });
+        }
+    }
+
+    Err(Error::UseRequiresRootSlots {
+        name: use_name.into(),
+        slots: required_slots.join(", ").into(),
+        src,
+        span,
+        related,
+    })
+}
+
 fn validate_child_experimental_features(
     svc: &ResolveService,
     realm_url: &Url,
@@ -637,6 +783,7 @@ fn validate_child_experimental_features(
                 let span = spans
                     .components
                     .get(child_name)
+                    .or_else(|| spans.uses.get(child_name))
                     .and_then(|component| component.manifest.or(Some(component.whole)))
                     .unwrap_or((0usize, 0usize).into());
                 (Some(src), Some(span))

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -27,7 +27,9 @@ mod targets;
 pub mod bundle;
 pub mod reporter;
 
-pub use frontend::{DigestStore, ResolveOptions, ResolvedNode, ResolvedTree, ResolverRegistry};
+pub use frontend::{
+    DigestStore, ResolveOptions, ResolvedNode, ResolvedPolicy, ResolvedTree, ResolverRegistry,
+};
 pub use linker::{ComponentProvenance, Provenance};
 
 #[derive(Clone, Debug, Default)]

--- a/compiler/src/lint.rs
+++ b/compiler/src/lint.rs
@@ -674,6 +674,28 @@ pub fn lint_manifest(
         }
     }
 
+    let policy_referenced_uses: BTreeSet<_> = manifest
+        .policies()
+        .iter()
+        .map(|policy| policy.alias.as_str())
+        .collect();
+
+    for use_name in manifest.uses().keys() {
+        if !policy_referenced_uses.contains(use_name.as_str()) {
+            let span = spans
+                .uses
+                .get(use_name.as_str())
+                .map(|s| s.name)
+                .unwrap_or((0usize, 0usize).into());
+            lints.push(ManifestLint::UnusedUse {
+                name: use_name.clone(),
+                component: component.clone(),
+                src: src.clone(),
+                span,
+            });
+        }
+    }
+
     for (env_name, env) in manifest.environments() {
         let mut seen = BTreeSet::new();
         for (idx, resolver) in env.resolvers.iter().enumerate() {
@@ -1337,6 +1359,47 @@ mod tests {
                 .iter()
                 .any(|lint| matches!(lint, crate::lint::ManifestLint::UnusedProgram { .. }))
         );
+    }
+
+    #[test]
+    fn unused_use_is_linted() {
+        let input = r#"
+        {
+          manifest_version: "0.1.0",
+          experimental_features: ["policies"],
+          use: {
+            wrapper: "./wrapper.json5",
+          },
+        }
+        "#;
+        let raw = parse_raw(input);
+        let manifest = raw.validate().unwrap();
+        let lints = lint_for(input, &manifest);
+        assert!(lints.iter().any(|lint| matches!(
+            lint,
+            crate::lint::ManifestLint::UnusedUse { name, .. } if name == "wrapper"
+        )));
+    }
+
+    #[test]
+    fn use_referenced_by_policy_is_not_linted() {
+        let input = r##"
+        {
+          manifest_version: "0.1.0",
+          experimental_features: ["policies"],
+          use: {
+            wrapper: "./wrapper.json5",
+          },
+          policies: ["#wrapper.rewrite"],
+        }
+        "##;
+        let raw = parse_raw(input);
+        let manifest = raw.validate().unwrap();
+        let lints = lint_for(input, &manifest);
+        assert!(!lints.iter().any(|lint| matches!(
+            lint,
+            crate::lint::ManifestLint::UnusedUse { name, .. } if name == "wrapper"
+        )));
     }
 
     #[test]

--- a/compiler/src/lint.rs
+++ b/compiler/src/lint.rs
@@ -1366,7 +1366,7 @@ mod tests {
         let input = r#"
         {
           manifest_version: "0.1.0",
-          experimental_features: ["policies"],
+          experimental_features: ["governance"],
           use: {
             wrapper: "./wrapper.json5",
           },
@@ -1386,7 +1386,7 @@ mod tests {
         let input = r##"
         {
           manifest_version: "0.1.0",
-          experimental_features: ["policies"],
+          experimental_features: ["governance"],
           use: {
             wrapper: "./wrapper.json5",
           },

--- a/compiler/src/tests/bundle.rs
+++ b/compiler/src/tests/bundle.rs
@@ -338,6 +338,7 @@ fn compile_from_tree_handles_malformed_program_image_from_builder() {
             config: None,
             children: BTreeMap::new(),
             uses: BTreeMap::new(),
+            policies: Vec::new(),
             child_templates: BTreeMap::new(),
         },
     };
@@ -403,6 +404,7 @@ fn check_from_tree_handles_malformed_program_image_from_builder_with_source() {
             config: None,
             children: BTreeMap::new(),
             uses: BTreeMap::new(),
+            policies: Vec::new(),
             child_templates: BTreeMap::new(),
         },
     };
@@ -441,6 +443,7 @@ async fn bundle_builder_reserializes_when_source_missing() {
             config: None,
             children: BTreeMap::new(),
             uses: BTreeMap::new(),
+            policies: Vec::new(),
             child_templates: BTreeMap::new(),
         },
     };

--- a/compiler/src/tests/bundle.rs
+++ b/compiler/src/tests/bundle.rs
@@ -337,6 +337,7 @@ fn compile_from_tree_handles_malformed_program_image_from_builder() {
             observed_url: None,
             config: None,
             children: BTreeMap::new(),
+            uses: BTreeMap::new(),
             child_templates: BTreeMap::new(),
         },
     };
@@ -401,6 +402,7 @@ fn check_from_tree_handles_malformed_program_image_from_builder_with_source() {
             observed_url: None,
             config: None,
             children: BTreeMap::new(),
+            uses: BTreeMap::new(),
             child_templates: BTreeMap::new(),
         },
     };
@@ -438,6 +440,7 @@ async fn bundle_builder_reserializes_when_source_missing() {
             observed_url: None,
             config: None,
             children: BTreeMap::new(),
+            uses: BTreeMap::new(),
             child_templates: BTreeMap::new(),
         },
     };

--- a/compiler/src/tests/features.rs
+++ b/compiler/src/tests/features.rs
@@ -555,6 +555,58 @@ async fn experimental_features_are_checked_per_edge() {
 }
 
 #[tokio::test]
+async fn experimental_features_are_checked_for_use_edges() {
+    let dir = tmp_dir("scenario-experimental-use-edge");
+    let root_path = dir.path().join("root.json5");
+    let used_path = dir.path().join("used.json5");
+
+    write_file(
+        &used_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          experimental_features: ["docker"],
+        }
+        "#,
+    );
+
+    write_file(
+        &root_path,
+        &format!(
+            r#"
+            {{
+              manifest_version: "0.1.0",
+              experimental_features: ["policies"],
+              use: {{
+                wrapper: "{used}",
+              }},
+            }}
+            "#,
+            used = file_url(&used_path)
+        ),
+    );
+
+    let compiler = default_compiler();
+    let root_ref = manifest_ref_for_path(&root_path);
+    let err = compiler
+        .compile(root_ref, CompileOptions::default())
+        .await
+        .expect_err("missing parent experimental feature on use edge should fail");
+
+    match err {
+        crate::Error::Frontend(crate::frontend::Error::ExperimentalFeatureNotEnabled {
+            child,
+            missing_features,
+            ..
+        }) => {
+            assert_eq!(child.as_ref(), "wrapper");
+            assert_eq!(missing_features.to_string(), "docker");
+        }
+        other => panic!("expected ExperimentalFeatureNotEnabled, got: {other}"),
+    }
+}
+
+#[tokio::test]
 async fn experimental_features_succeed_when_enabled_on_every_parent() {
     let dir = tmp_dir("scenario-experimental-enabled");
     let root_path = dir.path().join("root.json5");

--- a/compiler/src/tests/features.rs
+++ b/compiler/src/tests/features.rs
@@ -576,7 +576,7 @@ async fn experimental_features_are_checked_for_use_edges() {
             r#"
             {{
               manifest_version: "0.1.0",
-              experimental_features: ["policies"],
+              experimental_features: ["governance"],
               use: {{
                 wrapper: "{used}",
               }},

--- a/compiler/src/tests/resolution.rs
+++ b/compiler/src/tests/resolution.rs
@@ -480,3 +480,125 @@ async fn binding_rejects_duplicate_target_for_singular_child_slot() {
 
     assert!(error_contains(&err, "bound more than once"));
 }
+
+#[tokio::test]
+async fn resolve_tree_keeps_use_entries_out_of_component_tree() {
+    let dir = tmp_dir("scenario-use-resolution");
+    let root_path = dir.path().join("root.json5");
+    let child_path = dir.path().join("child.json5");
+    let wrapper_path = dir.path().join("wrapper.json5");
+
+    write_file(&child_path, r#"{ manifest_version: "0.1.0" }"#);
+    write_file(
+        &wrapper_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          program: {
+            image: "wrapper",
+            entrypoint: ["wrapper"],
+            network: { endpoints: [{ name: "api", port: 80 }] },
+          },
+          provides: { rewrite: { kind: "http", profile: "policy", endpoint: "api" } },
+          exports: { rewrite: "rewrite" },
+        }
+        "#,
+    );
+    write_file(
+        &root_path,
+        &format!(
+            r##"
+            {{
+              manifest_version: "0.1.0",
+              experimental_features: ["policies"],
+              use: {{
+                wrapper: "{wrapper}",
+              }},
+              policies: ["#wrapper.rewrite"],
+              components: {{
+                child: "{child}",
+              }},
+            }}
+            "##,
+            wrapper = file_url(&wrapper_path),
+            child = file_url(&child_path),
+        ),
+    );
+
+    let compiler = default_compiler();
+    let tree = compiler
+        .resolve_tree(
+            manifest_ref_for_path(&root_path),
+            standard_compile_options().resolve,
+        )
+        .await
+        .unwrap();
+
+    assert!(tree.root.children.contains_key("child"));
+    assert!(tree.root.uses.contains_key("wrapper"));
+
+    let output = compiler
+        .compile_from_tree(tree, standard_compile_options().optimize)
+        .unwrap();
+    assert_eq!(output.scenario.components.len(), 2);
+}
+
+#[tokio::test]
+async fn used_manifest_must_not_require_root_slots() {
+    let dir = tmp_dir("scenario-use-required-slot");
+    let root_path = dir.path().join("root.json5");
+    let wrapper_path = dir.path().join("wrapper.json5");
+
+    write_file(
+        &wrapper_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          slots: { upstream: { kind: "http" } },
+          program: {
+            image: "wrapper",
+            entrypoint: ["wrapper"],
+            network: { endpoints: [{ name: "api", port: 80 }] },
+          },
+          provides: { rewrite: { kind: "http", profile: "policy", endpoint: "api" } },
+          exports: { rewrite: "rewrite" },
+        }
+        "#,
+    );
+    write_file(
+        &root_path,
+        &format!(
+            r##"
+            {{
+              manifest_version: "0.1.0",
+              experimental_features: ["policies"],
+              use: {{
+                wrapper: "{wrapper}",
+              }},
+              policies: ["#wrapper.rewrite"],
+            }}
+            "##,
+            wrapper = file_url(&wrapper_path),
+        ),
+    );
+
+    let err = default_compiler()
+        .compile(
+            manifest_ref_for_path(&root_path),
+            standard_compile_options(),
+        )
+        .await
+        .unwrap_err();
+
+    match err {
+        crate::Error::Frontend(crate::frontend::Error::UseRequiresRootSlots {
+            name,
+            slots,
+            ..
+        }) => {
+            assert_eq!(name.as_ref(), "wrapper");
+            assert_eq!(slots.as_ref(), "upstream");
+        }
+        other => panic!("expected UseRequiresRootSlots error, got: {other}"),
+    }
+}

--- a/compiler/src/tests/resolution.rs
+++ b/compiler/src/tests/resolution.rs
@@ -510,7 +510,7 @@ async fn resolve_tree_keeps_use_entries_out_of_component_tree() {
             r##"
             {{
               manifest_version: "0.1.0",
-              experimental_features: ["policies"],
+              experimental_features: ["governance"],
               use: {{
                 wrapper: "{wrapper}",
               }},
@@ -571,7 +571,7 @@ async fn used_manifest_must_not_require_root_slots() {
             r##"
             {{
               manifest_version: "0.1.0",
-              experimental_features: ["policies"],
+              experimental_features: ["governance"],
               use: {{
                 wrapper: "{wrapper}",
               }},
@@ -630,7 +630,7 @@ async fn resolve_tree_resolves_policy_exports_from_use_entries() {
             r##"
             {{
               manifest_version: "0.1.0",
-              experimental_features: ["policies"],
+              experimental_features: ["governance"],
               use: {{
                 wrapper: "{wrapper}",
               }},
@@ -705,7 +705,7 @@ async fn resolve_tree_follows_child_exports_for_policies() {
             r##"
             {{
               manifest_version: "0.1.0",
-              experimental_features: ["policies"],
+              experimental_features: ["governance"],
               use: {{
                 wrapper: "{wrapper}",
               }},
@@ -748,7 +748,7 @@ async fn policy_ref_requires_resolvable_export() {
             r##"
             {{
               manifest_version: "0.1.0",
-              experimental_features: ["policies"],
+              experimental_features: ["governance"],
               use: {{
                 wrapper: "{wrapper}",
               }},
@@ -809,7 +809,7 @@ async fn policy_ref_requires_http_policy_provide() {
             r##"
             {{
               manifest_version: "0.1.0",
-              experimental_features: ["policies"],
+              experimental_features: ["governance"],
               use: {{
                 wrapper: "{wrapper}",
               }},
@@ -866,7 +866,7 @@ async fn policy_ref_rejects_slot_exports() {
             r##"
             {{
               manifest_version: "0.1.0",
-              experimental_features: ["policies"],
+              experimental_features: ["governance"],
               use: {{
                 wrapper: "{wrapper}",
               }},

--- a/compiler/src/tests/resolution.rs
+++ b/compiler/src/tests/resolution.rs
@@ -602,3 +602,298 @@ async fn used_manifest_must_not_require_root_slots() {
         other => panic!("expected UseRequiresRootSlots error, got: {other}"),
     }
 }
+
+#[tokio::test]
+async fn resolve_tree_resolves_policy_exports_from_use_entries() {
+    let dir = tmp_dir("scenario-policy-resolve");
+    let root_path = dir.path().join("root.json5");
+    let wrapper_path = dir.path().join("wrapper.json5");
+
+    write_file(
+        &wrapper_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          program: {
+            image: "wrapper",
+            entrypoint: ["wrapper"],
+            network: { endpoints: [{ name: "api", port: 80 }] },
+          },
+          provides: { rewrite: { kind: "http", profile: "policy", endpoint: "api" } },
+          exports: { rewrite: "rewrite" },
+        }
+        "#,
+    );
+    write_file(
+        &root_path,
+        &format!(
+            r##"
+            {{
+              manifest_version: "0.1.0",
+              experimental_features: ["policies"],
+              use: {{
+                wrapper: "{wrapper}",
+              }},
+              policies: ["#wrapper.rewrite"],
+            }}
+            "##,
+            wrapper = file_url(&wrapper_path),
+        ),
+    );
+
+    let tree = default_compiler()
+        .resolve_tree(
+            manifest_ref_for_path(&root_path),
+            standard_compile_options().resolve,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(tree.root.policies.len(), 1);
+    assert_eq!(tree.root.policies[0].reference.alias, "wrapper");
+    assert_eq!(tree.root.policies[0].reference.export, "rewrite");
+    assert_eq!(
+        tree.root.policies[0].capability.kind,
+        amber_manifest::CapabilityKind::Http
+    );
+    assert_eq!(
+        tree.root.policies[0].capability.profile.as_deref(),
+        Some("policy")
+    );
+}
+
+#[tokio::test]
+async fn resolve_tree_follows_child_exports_for_policies() {
+    let dir = tmp_dir("scenario-policy-child-export");
+    let root_path = dir.path().join("root.json5");
+    let wrapper_path = dir.path().join("wrapper.json5");
+    let leaf_path = dir.path().join("leaf.json5");
+
+    write_file(
+        &leaf_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          program: {
+            image: "leaf",
+            entrypoint: ["leaf"],
+            network: { endpoints: [{ name: "api", port: 80 }] },
+          },
+          provides: { rewrite: { kind: "http", profile: "policy", endpoint: "api" } },
+          exports: { rewrite: "rewrite" },
+        }
+        "#,
+    );
+    write_file(
+        &wrapper_path,
+        &format!(
+            r##"
+            {{
+              manifest_version: "0.1.0",
+              components: {{
+                leaf: "{leaf}",
+              }},
+              exports: {{ rewrite: "#leaf.rewrite" }},
+            }}
+            "##,
+            leaf = file_url(&leaf_path),
+        ),
+    );
+    write_file(
+        &root_path,
+        &format!(
+            r##"
+            {{
+              manifest_version: "0.1.0",
+              experimental_features: ["policies"],
+              use: {{
+                wrapper: "{wrapper}",
+              }},
+              policies: ["#wrapper.rewrite"],
+            }}
+            "##,
+            wrapper = file_url(&wrapper_path),
+        ),
+    );
+
+    let tree = default_compiler()
+        .resolve_tree(
+            manifest_ref_for_path(&root_path),
+            standard_compile_options().resolve,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(tree.root.policies.len(), 1);
+    assert_eq!(
+        tree.root.policies[0].capability.kind,
+        amber_manifest::CapabilityKind::Http
+    );
+    assert_eq!(
+        tree.root.policies[0].capability.profile.as_deref(),
+        Some("policy")
+    );
+}
+
+#[tokio::test]
+async fn policy_ref_requires_resolvable_export() {
+    let dir = tmp_dir("scenario-policy-missing-export");
+    let root_path = dir.path().join("root.json5");
+    let wrapper_path = dir.path().join("wrapper.json5");
+
+    write_file(&wrapper_path, r#"{ manifest_version: "0.1.0" }"#);
+    write_file(
+        &root_path,
+        &format!(
+            r##"
+            {{
+              manifest_version: "0.1.0",
+              experimental_features: ["policies"],
+              use: {{
+                wrapper: "{wrapper}",
+              }},
+              policies: ["#wrapper.rewrite"],
+            }}
+            "##,
+            wrapper = file_url(&wrapper_path),
+        ),
+    );
+
+    let err = default_compiler()
+        .resolve_tree(
+            manifest_ref_for_path(&root_path),
+            standard_compile_options().resolve,
+        )
+        .await
+        .unwrap_err();
+
+    match err {
+        crate::Error::Frontend(crate::frontend::Error::PolicyExportUnresolved {
+            policy,
+            use_name,
+            export,
+            ..
+        }) => {
+            assert_eq!(policy.as_ref(), "#wrapper.rewrite");
+            assert_eq!(use_name.as_ref(), "wrapper");
+            assert_eq!(export.as_ref(), "rewrite");
+        }
+        other => panic!("expected PolicyExportUnresolved error, got: {other}"),
+    }
+}
+
+#[tokio::test]
+async fn policy_ref_requires_http_policy_provide() {
+    let dir = tmp_dir("scenario-policy-invalid-capability");
+    let root_path = dir.path().join("root.json5");
+    let wrapper_path = dir.path().join("wrapper.json5");
+
+    write_file(
+        &wrapper_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          program: {
+            image: "wrapper",
+            entrypoint: ["wrapper"],
+            network: { endpoints: [{ name: "api", port: 80 }] },
+          },
+          provides: { rewrite: { kind: "http", endpoint: "api" } },
+          exports: { rewrite: "rewrite" },
+        }
+        "#,
+    );
+    write_file(
+        &root_path,
+        &format!(
+            r##"
+            {{
+              manifest_version: "0.1.0",
+              experimental_features: ["policies"],
+              use: {{
+                wrapper: "{wrapper}",
+              }},
+              policies: ["#wrapper.rewrite"],
+            }}
+            "##,
+            wrapper = file_url(&wrapper_path),
+        ),
+    );
+
+    let err = default_compiler()
+        .resolve_tree(
+            manifest_ref_for_path(&root_path),
+            standard_compile_options().resolve,
+        )
+        .await
+        .unwrap_err();
+
+    match err {
+        crate::Error::Frontend(crate::frontend::Error::InvalidPolicyExport {
+            policy,
+            message,
+            ..
+        }) => {
+            assert_eq!(policy.as_ref(), "#wrapper.rewrite");
+            assert_eq!(
+                message.as_ref(),
+                "must resolve to an `http` provide with profile `policy`, got `http`"
+            );
+        }
+        other => panic!("expected InvalidPolicyExport error, got: {other}"),
+    }
+}
+
+#[tokio::test]
+async fn policy_ref_rejects_slot_exports() {
+    let dir = tmp_dir("scenario-policy-slot-export");
+    let root_path = dir.path().join("root.json5");
+    let wrapper_path = dir.path().join("wrapper.json5");
+
+    write_file(
+        &wrapper_path,
+        r#"
+        {
+          manifest_version: "0.1.0",
+          slots: { rewrite: { kind: "http", profile: "policy", optional: true } },
+          exports: { rewrite: "rewrite" },
+        }
+        "#,
+    );
+    write_file(
+        &root_path,
+        &format!(
+            r##"
+            {{
+              manifest_version: "0.1.0",
+              experimental_features: ["policies"],
+              use: {{
+                wrapper: "{wrapper}",
+              }},
+              policies: ["#wrapper.rewrite"],
+            }}
+            "##,
+            wrapper = file_url(&wrapper_path),
+        ),
+    );
+
+    let err = default_compiler()
+        .resolve_tree(
+            manifest_ref_for_path(&root_path),
+            standard_compile_options().resolve,
+        )
+        .await
+        .unwrap_err();
+
+    match err {
+        crate::Error::Frontend(crate::frontend::Error::InvalidPolicyExport {
+            policy,
+            message,
+            ..
+        }) => {
+            assert_eq!(policy.as_ref(), "#wrapper.rewrite");
+            assert_eq!(message.as_ref(), "must resolve to a provide, not a slot");
+        }
+        other => panic!("expected InvalidPolicyExport error, got: {other}"),
+    }
+}


### PR DESCRIPTION
Milestone 1 for the new experimental feature called `governance`. 

This PR:
- Adds `use` and `policies` manifest syntax
  - `use` declares auxiliary components for meta/governance purposes; these are kept out of the scenario graph
  - `policies` declares an ordered list of policy capability refs
- Validates that `use` components are self-contained (no required root slots)
- Resolves and validates policy refs; refs must resolve to exported `http` provides with profile `policy`, from the local `use` set
- Warnings for unused `use` entries
- Tests and UI diagnostics for the new syntax

This does not execute policies yet, it's frontend-only.